### PR TITLE
DON-17 fix: /verify API 에러 처리를 표준 HTTP 상태코드로 변경

### DIFF
--- a/src/v1/auth/auth.controller.ts
+++ b/src/v1/auth/auth.controller.ts
@@ -6,6 +6,9 @@ import {
     Request,
     HttpCode,
     HttpStatus,
+    UnauthorizedException,
+    BadRequestException,
+    InternalServerErrorException,
 } from '@nestjs/common';
 import { AuthService } from './auth.service';
 import { LoginDto } from './dto/login.dto';
@@ -51,20 +54,41 @@ export class AuthController {
 
     // 토큰 유효성 검증
     // verifyTokenDto: 검증할 토큰 DTO
-    // return: 검증 결과 및 사용자 정보
+    // return: 검증 성공 시 사용자 정보
     @Post('verify')
     @HttpCode(HttpStatus.OK)
     async verifyToken(@Body() verifyTokenDto: VerifyTokenDto): Promise<{
-        isValid: boolean;
-        user?: {
-            userId: number;
-            login_id: string;
-            name: string;
-            role: string;
-            club_id: number | null;
-        };
-        error?: string;
+        userId: number;
+        login_id: string;
+        name: string;
+        role: string;
+        club_id: number | null;
     }> {
-        return this.authService.verifyAccessToken(verifyTokenDto.token);
+        try {
+            return await this.authService.verifyAccessToken(verifyTokenDto.token);
+        } catch (error) {
+            if (error.name === 'TokenExpiredError') {
+                throw new UnauthorizedException({
+                    message: '토큰이 만료되었습니다.',
+                    errorCode: 'TOKEN_EXPIRED',
+                    type: 'AUTHENTICATION_ERROR'
+                });
+            } else if (error.name === 'JsonWebTokenError') {
+                throw new BadRequestException({
+                    message: '유효하지 않은 토큰입니다.',
+                    errorCode: 'INVALID_TOKEN',
+                    type: 'VALIDATION_ERROR'
+                });
+            } else if (error instanceof UnauthorizedException) {
+                // 서비스에서 발생한 UnauthorizedException은 그대로 전달
+                throw error;
+            } else {
+                throw new InternalServerErrorException({
+                    message: '토큰 검증 중 오류가 발생했습니다.',
+                    errorCode: 'VERIFICATION_ERROR',
+                    type: 'INTERNAL_ERROR'
+                });
+            }
+        }
     }
 }

--- a/src/v1/auth/auth.service.ts
+++ b/src/v1/auth/auth.service.ts
@@ -234,72 +234,46 @@ export class AuthService {
 
     // 액세스 토큰 수동 검증
     // token: 검증할 토큰
-    // return: 검증 결과 및 사용자 정보
+    // return: 검증 성공 시 사용자 정보
     async verifyAccessToken(token: string): Promise<{
-        isValid: boolean;
-        user?: {
-            userId: number;
-            login_id: string;
-            name: string;
-            role: string;
-            club_id: number | null;
-        };
-        error?: string;
+        userId: number;
+        login_id: string;
+        name: string;
+        role: string;
+        club_id: number | null;
     }> {
-        try {
-            const accessSecret = this.configService.get<string>('JWT_ACCESS_SECRET');
-            if (!accessSecret) {
-                throw new Error('JWT_ACCESS_SECRET 환경변수가 설정되지 않았습니다.');
-            }
-
-            // 토큰 디코딩 및 서명 검증
-            const decoded = this.jwtService.verify(token, { 
-                secret: accessSecret 
-            });
-
-            // 사용자 조회
-            const user = await this.usersService.findOne(decoded.sub);
-            if (!user) {
-                throw new UnauthorizedException('사용자를 찾을 수 없습니다.');
-            }
-
-            // 토큰 페이로드와 DB 정보 일치 확인
-            if (
-                user.login_id !== decoded.login_id ||
-                user.name !== decoded.name ||
-                normalizeRole(user.role) !== decoded.role ||
-                user.club_id !== decoded.club_id
-            ) {
-                throw new UnauthorizedException('토큰 정보가 일치하지 않습니다.');
-            }
-
-            return {
-                isValid: true,
-                user: {
-                    userId: user.id,
-                    login_id: user.login_id,
-                    name: user.name,
-                    role: user.role,
-                    club_id: user.club_id
-                }
-            };
-        } catch (error) {
-            if (error.name === 'TokenExpiredError') {
-                return { 
-                    isValid: false, 
-                    error: '토큰이 만료되었습니다.' 
-                };
-            } else if (error.name === 'JsonWebTokenError') {
-                return { 
-                    isValid: false, 
-                    error: '유효하지 않은 토큰입니다.' 
-                };
-            } else {
-                return { 
-                    isValid: false, 
-                    error: '토큰 검증 중 오류가 발생했습니다.' 
-                };
-            }
+        const accessSecret = this.configService.get<string>('JWT_ACCESS_SECRET');
+        if (!accessSecret) {
+            throw new Error('JWT_ACCESS_SECRET 환경변수가 설정되지 않았습니다.');
         }
+
+        // 토큰 디코딩 및 서명 검증
+        const decoded = this.jwtService.verify(token, { 
+            secret: accessSecret 
+        });
+
+        // 사용자 조회
+        const user = await this.usersService.findOne(decoded.sub);
+        if (!user) {
+            throw new UnauthorizedException('사용자를 찾을 수 없습니다.');
+        }
+
+        // 토큰 페이로드와 DB 정보 일치 확인
+        if (
+            user.login_id !== decoded.login_id ||
+            user.name !== decoded.name ||
+            normalizeRole(user.role) !== decoded.role ||
+            user.club_id !== decoded.club_id
+        ) {
+            throw new UnauthorizedException('토큰 정보가 일치하지 않습니다.');
+        }
+
+        return {
+            userId: user.id,
+            login_id: user.login_id,
+            name: user.name,
+            role: user.role,
+            club_id: user.club_id
+        };
     }
 }


### PR DESCRIPTION
- JWT 에러별 적절한 HTTP 상태코드 반환 (401/400/500)
- 에러 정보에 errorCode, type 필드 추가로 세밀한 분류
- 기존 HTTP 200 + 에러 메시지 방식에서 표준 REST API 구조로 개선