### PR TITLE
운영 배포에 `verify:fast` 게이트 및 `migration-check` 분리 추가

### DIFF
--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -11,9 +11,62 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  verify-fast:
+    if: github.event_name != 'workflow_dispatch' || github.ref_name == 'main'
+    runs-on: ubuntu-latest
+
+    env:
+      NODE_VERSION: '22'
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+          cache: yarn
+
+      - name: Install dependencies
+        run: yarn install --frozen-lockfile
+
+      - name: Required production gate
+        run: yarn verify:fast
+
+  migration-check:
+    if: github.event_name != 'workflow_dispatch' || github.ref_name == 'main'
+    runs-on: ubuntu-latest
+    needs: verify-fast
+
+    env:
+      NODE_VERSION: '22'
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+          cache: yarn
+
+      - name: Install dependencies
+        run: yarn install --frozen-lockfile
+
+      - name: Build before migration check
+        run: yarn build
+
+      - name: Check migrations
+        run: yarn migration:check
+
   deploy:
     if: github.event_name != 'workflow_dispatch' || github.ref_name == 'main'
     runs-on: ubuntu-latest
+    needs:
+      - verify-fast
+      - migration-check
     environment:
       name: production
 

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -17,20 +17,43 @@
 
 1. 의존성 설치
 2. `yarn build`
+3. `yarn lint:check`
+4. `yarn test --runInBand`
+5. `yarn migration:check`
 
-배포 워크플로우는 아래 순서로 동작합니다.
+개발 배포 워크플로우는 아래 순서로 동작합니다.
 
 1. 의존성 설치
-2. 개발 배포는 `yarn verify:fast`
+2. `yarn verify:fast`
 3. `yarn build`
 4. `dist`, `package.json`, `yarn.lock`, PM2 설정 파일 압축
 5. Lightsail로 업로드
 6. 서버에서 압축 해제
 7. `yarn install --frozen-lockfile --production=true`
-8. `NODE_ENV=<environment> yarn migration:run`
+8. `NODE_ENV=development yarn migration:run`
 9. `pm2 startOrReload ... --update-env`
 10. 내부 헬스체크 확인
 11. 외부 헬스체크 확인
+
+운영 배포 워크플로우는 아래 순서로 동작합니다.
+
+1. `verify:fast` job에서 의존성 설치
+2. `verify:fast` job에서 배포 산출물 생성 전 `yarn verify:fast`
+3. migration 검증 job에서 의존성 설치
+4. migration 검증 job에서 `yarn build`
+5. migration 검증 job에서 `yarn migration:check`
+6. 배포 job에서 의존성 설치
+7. 배포 job에서 `yarn build`
+8. `dist`, `package.json`, `yarn.lock`, PM2 설정 파일 압축
+9. Lightsail로 업로드
+10. 서버에서 압축 해제
+11. `yarn install --frozen-lockfile --production=true`
+12. `NODE_ENV=production yarn migration:run`
+13. `pm2 startOrReload ... --update-env`
+14. 내부 헬스체크 확인
+15. 외부 헬스체크 확인
+
+운영 배포에서는 `verify:fast` job이 `verify:docs`, `type`, `test`를 필수 gate로 실행합니다. migration 검증은 별도 job으로 분리하되, TypeORM 설정이 빌드 산출물의 `dist/database/data-source.js`를 사용하므로 반드시 `yarn build` 이후 `yarn migration:check` 순서로 실행합니다.
 
 운영 배포는 GitHub Environment `production` 승인 후 진행됩니다. 저장소 설정에서 `Settings > Environments > production`을 만들고 `Required reviewers`를 지정해야 합니다.
 
@@ -127,6 +150,7 @@ pm2 startup
 - `.env.production`, `.env.development`는 저장소에 커밋하지 않습니다.
 - 운영 비밀값은 GitHub Secrets보다 서버 내 환경파일로 관리하는 편이 안전합니다.
 - 개발 배포 워크플로우는 배포 전에 `yarn verify:fast`를 실행합니다.
-- 운영 배포 워크플로우는 현재 배포 우선을 위해 `lint`, `test` 단계를 제외한 상태이지만, 배포 후 외부 헬스체크는 수행합니다.
+- 운영 배포 워크플로우는 배포 산출물 생성 전에 `yarn verify:fast`를 필수 gate로 실행하며, `verify:docs`, `type`, `test`를 통과해야 배포 job이 시작됩니다.
+- 운영 migration 검증은 별도 job에서 수행하고, `yarn build` 이후 `yarn migration:check` 순서를 유지합니다.
 - DB 설정은 `synchronize: false`입니다. 스키마 변경은 TypeORM migration으로 추가하고, 배포 중 앱 재시작 전에 실행합니다.
 - 운영 배포 승인 전에 migration 내용을 확인하세요. `down` migration은 롤백 보조용이며, 운영 데이터가 있는 컬럼 삭제는 별도 판단이 필요합니다.


### PR DESCRIPTION
### Motivation
- 운영 배포에서 산출물 생성 전에 필수 검증을 실행해 배포 리스크를 줄이기 위해 `verify:fast`를 배포 파이프라인의 gate로 추가했습니다.
- TypeORM migration 검증은 빌드 산출물을 필요로 하므로 `yarn build` 이후 별도 job으로 분리해 순서를 명확히 하려는 목적입니다.
- 문서(`docs/deployment.md`)는 실제 워크플로우 변경을 반영하도록 갱신합니다.

### Description
- `.github/workflows/deploy-prod.yml`에 `verify-fast` job을 추가해 배포 산출물 생성 전에 `yarn verify:fast`를 실행하도록 했습니다.
- 동일 파일에 `migration-check` job을 추가하고 `needs: verify-fast`로 연결해 `yarn build` 이후 `yarn migration:check`를 실행하도록 분리했습니다.
- `deploy` job은 이제 `needs: [verify-fast, migration-check]`를 요구하도록 변경되어 검증과 migration 체크가 모두 통과되어야 배포가 진행됩니다.
- `docs/deployment.md`의 배포 순서 및 운영 검증 정책 문구를 새 정책(`verify:docs`, `type`, `test` 포함)과 migration 순서에 맞게 갱신했습니다.

### Testing
- `yarn verify:fast`를 실행해 문서 계약, 타입 검사, 단위 테스트 경로(`verify:docs -> type -> test`)가 통과되었으며 성공했습니다.
- `yarn build && yarn migration:check`를 실행해 빌드 및 migration 검증이 수행되어 `Detected 1 migration path(s).` 메시지로 성공했습니다.
- 단위 테스트(`jest`) 결과로 Test Suites: 7 passed, Tests: 7 passed로 모든 테스트가 성공했습니다.
- 워크플로우 패턴 검증 스크립트(`python` 체크)와 `git diff --check`도 성공했습니다.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fc0c41e67c832986c55540e7d1b50f)