### PR TITLE
test: 인증 토큰 흐름 단위 테스트 추가

### DIFF
--- a/docs/evals/known-gaps.md
+++ b/docs/evals/known-gaps.md
@@ -16,8 +16,7 @@
 
 ## 우선순위 높은 공백
 
-- auth service의 로그인 실패, refresh token, JWT payload 분기
-- JWT strategy의 사용자 조회 실패와 비활성/삭제 사용자 처리
+- JWT strategy의 비활성/삭제 사용자 처리
 - S3 업로드 helper의 key 생성, MIME 검증, 실패 응답 mapping
 - TypeORM entity와 DTO 사이 payload mapping 규칙
 - DB 제약과 service validation이 겹치는 중복/무결성 에러 처리

--- a/docs/evals/success-criteria.md
+++ b/docs/evals/success-criteria.md
@@ -15,6 +15,7 @@
 - 루트 컨트롤러는 앱의 기본 응답을 반환해야 한다.
 
 관련 테스트:
+
 - [app.controller.spec.ts](../../src/app.controller.spec.ts)
 
 ## Clubs
@@ -25,6 +26,7 @@
 - controller는 service 결과와 예외를 의도한 HTTP 흐름으로 전달해야 한다.
 
 관련 테스트:
+
 - [clubs.service.spec.ts](../../src/v1/clubs/clubs.service.spec.ts)
 - [clubs.controller.spec.ts](../../src/v1/clubs/clubs.controller.spec.ts)
 
@@ -37,6 +39,7 @@
 - 사용자 중복, 역할, 식별자 조건은 service 계약대로 처리되어야 한다.
 
 관련 테스트:
+
 - [users.service.spec.ts](../../src/v1/users/users.service.spec.ts)
 - [users.controller.spec.ts](../../src/v1/users/users.controller.spec.ts)
 
@@ -48,8 +51,33 @@
 - controller는 업로드 파일과 요청 payload를 service 계약에 맞게 전달해야 한다.
 
 관련 테스트:
+
 - [club_reports.service.spec.ts](../../src/v1/club_reports/club_reports.service.spec.ts)
 - [club_reports.controller.spec.ts](../../src/v1/club_reports/club_reports.controller.spec.ts)
+
+## Auth
+
+### 로그인과 refresh token
+
+- 로그인은 사용자 검증 실패 시 토큰을 생성하거나 refresh token을 저장하지 않고 거부해야 한다.
+- 로그인 성공 시 access/refresh token을 생성하고 생성된 refresh token을 사용자 저장소에 저장해야 한다.
+- refresh token 재발급은 만료/invalid token, 저장된 token 불일치, 사용자 없음 상태를 거부해야 한다.
+- refresh token 재발급 성공 시 token rotation을 수행하고 새 refresh token을 사용자 저장소에 저장해야 한다.
+
+관련 테스트:
+
+- [auth.service.spec.ts](../../src/v1/auth/auth.service.spec.ts)
+
+### JWT payload 검증
+
+- JWT payload는 사용자 존재 여부와 `login_id`/`name`/`role` 일치 여부를 검증해야 한다.
+- president payload의 `club_id`는 현재 관리 중인 동아리 ID와 일치해야 한다.
+- president가 아닌 사용자의 payload에는 `club_id`가 포함되면 안 된다.
+- 정상 payload는 인증 컨텍스트에서 사용할 사용자 식별 정보로 변환되어야 한다.
+
+관련 테스트:
+
+- [jwt.strategy.spec.ts](../../src/v1/auth/strategies/jwt.strategy.spec.ts)
 
 ## HTTP Lifecycle
 
@@ -58,4 +86,5 @@
 - Nest 앱은 테스트 환경에서 정상 부팅되어 기본 HTTP 요청을 처리해야 한다.
 
 관련 테스트:
+
 - [app.e2e-spec.ts](../../test/app.e2e-spec.ts)

--- a/docs/evals/test-inventory.md
+++ b/docs/evals/test-inventory.md
@@ -10,18 +10,20 @@
 
 ## 기본 테스트
 
-| 영역 | 파일 | 검증 방식 | 비고 |
-| --- | --- | --- | --- |
-| app | [app.controller.spec.ts](../../src/app.controller.spec.ts) | code-graded | 기본 컨트롤러 응답 |
-| clubs | [clubs.service.spec.ts](../../src/v1/clubs/clubs.service.spec.ts) | code-graded | 동아리 service 계약 |
-| clubs | [clubs.controller.spec.ts](../../src/v1/clubs/clubs.controller.spec.ts) | code-graded | 동아리 controller 계약 |
-| users | [users.service.spec.ts](../../src/v1/users/users.service.spec.ts) | code-graded | 사용자 service 계약 |
-| users | [users.controller.spec.ts](../../src/v1/users/users.controller.spec.ts) | code-graded | 사용자 controller 계약 |
-| club reports | [club_reports.service.spec.ts](../../src/v1/club_reports/club_reports.service.spec.ts) | code-graded | 활동보고서 service 계약 |
-| club reports | [club_reports.controller.spec.ts](../../src/v1/club_reports/club_reports.controller.spec.ts) | code-graded | 활동보고서 controller 계약 |
+| 영역         | 파일                                                                                         | 검증 방식   | 비고                                               |
+| ------------ | -------------------------------------------------------------------------------------------- | ----------- | -------------------------------------------------- |
+| app          | [app.controller.spec.ts](../../src/app.controller.spec.ts)                                   | code-graded | 기본 컨트롤러 응답                                 |
+| clubs        | [clubs.service.spec.ts](../../src/v1/clubs/clubs.service.spec.ts)                            | code-graded | 동아리 service 계약                                |
+| clubs        | [clubs.controller.spec.ts](../../src/v1/clubs/clubs.controller.spec.ts)                      | code-graded | 동아리 controller 계약                             |
+| users        | [users.service.spec.ts](../../src/v1/users/users.service.spec.ts)                            | code-graded | 사용자 service 계약                                |
+| users        | [users.controller.spec.ts](../../src/v1/users/users.controller.spec.ts)                      | code-graded | 사용자 controller 계약                             |
+| club reports | [club_reports.service.spec.ts](../../src/v1/club_reports/club_reports.service.spec.ts)       | code-graded | 활동보고서 service 계약                            |
+| club reports | [club_reports.controller.spec.ts](../../src/v1/club_reports/club_reports.controller.spec.ts) | code-graded | 활동보고서 controller 계약                         |
+| auth         | [auth.service.spec.ts](../../src/v1/auth/auth.service.spec.ts)                               | code-graded | 로그인 실패/성공, refresh token 실패/rotation 계약 |
+| auth         | [jwt.strategy.spec.ts](../../src/v1/auth/strategies/jwt.strategy.spec.ts)                    | code-graded | JWT payload 사용자 정보/club_id 검증 계약          |
 
 ## 잔존 E2E
 
-| 영역 | 파일 | 현재 목적 | 상태 |
-| --- | --- | --- | --- |
-| app | [app.e2e-spec.ts](../../test/app.e2e-spec.ts) | Nest 앱 부트스트랩과 기본 HTTP lifecycle 확인 | 유지 |
+| 영역 | 파일                                          | 현재 목적                                     | 상태 |
+| ---- | --------------------------------------------- | --------------------------------------------- | ---- |
+| app  | [app.e2e-spec.ts](../../test/app.e2e-spec.ts) | Nest 앱 부트스트랩과 기본 HTTP lifecycle 확인 | 유지 |

--- a/src/v1/auth/auth.service.spec.ts
+++ b/src/v1/auth/auth.service.spec.ts
@@ -1,0 +1,275 @@
+import { UnauthorizedException } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+import { JwtService } from '@nestjs/jwt';
+import { Repository } from 'typeorm';
+import { Club } from '../clubs/entities/club.entity';
+import { User } from '../users/entities/user.entity';
+import { UsersService } from '../users/users.service';
+import { AuthService } from './auth.service';
+import { OneTimeKey } from './entities/one_time_key.entity';
+
+type MockedUsersService = Pick<
+    UsersService,
+    'validateUser' | 'findOneIncludingSystem' | 'updateRefreshToken'
+>;
+
+describe('AuthService', () => {
+    let service: AuthService;
+    let usersService: jest.Mocked<MockedUsersService>;
+    let jwtService: jest.Mocked<Pick<JwtService, 'sign' | 'verify'>>;
+    let configService: {
+        get: jest.Mock;
+    };
+    let clubRepository: {
+        createQueryBuilder: jest.Mock;
+    };
+    let clubQueryBuilder: {
+        where: jest.Mock;
+        andWhere: jest.Mock;
+        getOne: jest.Mock;
+    };
+
+    const adminUser = {
+        id: 1,
+        login_id: 'admin_login',
+        name: '관리자',
+        role: 'admin',
+        refresh_token: 'stored-refresh-token',
+    } as User;
+
+    const presidentUser = {
+        id: 2,
+        login_id: 'president_login',
+        name: '회장',
+        role: 'president',
+        refresh_token: 'stored-refresh-token',
+    } as User;
+
+    beforeEach(() => {
+        usersService = {
+            validateUser: jest.fn(),
+            findOneIncludingSystem: jest.fn(),
+            updateRefreshToken: jest.fn(),
+        };
+        jwtService = {
+            sign: jest.fn(),
+            verify: jest.fn(),
+        };
+        configService = {
+            get: jest.fn((key: string) => {
+                const values: Record<string, string> = {
+                    JWT_ACCESS_SECRET: 'access-secret',
+                    JWT_REFRESH_SECRET: 'refresh-secret',
+                    JWT_ACCESS_EXPIRE_TIME: '15m',
+                    JWT_REFRESH_EXPIRE_TIME: '7d',
+                };
+
+                return values[key];
+            }),
+        };
+        clubQueryBuilder = {
+            where: jest.fn().mockReturnThis(),
+            andWhere: jest.fn().mockReturnThis(),
+            getOne: jest.fn(),
+        };
+        clubRepository = {
+            createQueryBuilder: jest.fn().mockReturnValue(clubQueryBuilder),
+        };
+
+        service = new AuthService(
+            usersService as unknown as UsersService,
+            jwtService as unknown as JwtService,
+            configService as unknown as ConfigService,
+            {} as Repository<OneTimeKey>,
+            clubRepository as unknown as Repository<Club>,
+        );
+    });
+
+    describe('login', () => {
+        it('사용자가 없거나 비밀번호 검증에 실패하면 UnauthorizedException을 던진다', async () => {
+            usersService.validateUser.mockResolvedValue(null);
+
+            await expect(
+                service.login({
+                    login_id: 'missing_user',
+                    password: 'wrong_password',
+                }),
+            ).rejects.toBeInstanceOf(UnauthorizedException);
+
+            expect(usersService.validateUser).toHaveBeenCalledWith(
+                'missing_user',
+                'wrong_password',
+            );
+            expect(jwtService.sign).not.toHaveBeenCalled();
+            expect(usersService.updateRefreshToken).not.toHaveBeenCalled();
+        });
+
+        it('토큰을 생성하고 생성된 refresh token 저장을 호출한다', async () => {
+            usersService.validateUser.mockResolvedValue(adminUser);
+            jwtService.sign
+                .mockReturnValueOnce('new-access-token')
+                .mockReturnValueOnce('new-refresh-token');
+
+            const result = await service.login({
+                login_id: 'admin_login',
+                password: 'password',
+            });
+
+            expect(result).toEqual({
+                accessToken: 'new-access-token',
+                refreshToken: 'new-refresh-token',
+                tokenType: 'Bearer',
+                expiresIn: 15 * 60 * 1000,
+            });
+            expect(jwtService.sign).toHaveBeenNthCalledWith(
+                1,
+                {
+                    sub: adminUser.id,
+                    login_id: adminUser.login_id,
+                    name: adminUser.name,
+                    role: 'admin',
+                    club_id: null,
+                },
+                { secret: 'access-secret', expiresIn: '15m' },
+            );
+            expect(jwtService.sign).toHaveBeenNthCalledWith(
+                2,
+                {
+                    sub: adminUser.id,
+                    login_id: adminUser.login_id,
+                    name: adminUser.name,
+                    role: 'admin',
+                    club_id: null,
+                },
+                { secret: 'refresh-secret', expiresIn: '7d' },
+            );
+            expect(usersService.updateRefreshToken).toHaveBeenCalledWith(
+                adminUser.id,
+                'new-refresh-token',
+            );
+            expect(clubRepository.createQueryBuilder).not.toHaveBeenCalled();
+        });
+
+        it('president 로그인 토큰에는 관리 중인 club_id를 포함한다', async () => {
+            usersService.validateUser.mockResolvedValue(presidentUser);
+            clubQueryBuilder.getOne.mockResolvedValue({ id: 10 } as Club);
+            jwtService.sign
+                .mockReturnValueOnce('president-access-token')
+                .mockReturnValueOnce('president-refresh-token');
+
+            await service.login({
+                login_id: 'president_login',
+                password: 'password',
+            });
+
+            expect(clubQueryBuilder.where).toHaveBeenCalledWith(
+                'club.president_id = :userId',
+                { userId: presidentUser.id },
+            );
+            expect(clubQueryBuilder.andWhere).toHaveBeenCalledWith(
+                'club.deleted_at IS NULL',
+            );
+            expect(jwtService.sign).toHaveBeenNthCalledWith(
+                1,
+                expect.objectContaining({ club_id: 10, role: 'president' }),
+                expect.any(Object),
+            );
+        });
+    });
+
+    describe('refreshToken', () => {
+        it('만료된 refresh token이면 UnauthorizedException을 던진다', async () => {
+            const error = new Error('jwt expired');
+            error.name = 'TokenExpiredError';
+            jwtService.verify.mockImplementation(() => {
+                throw error;
+            });
+
+            await expect(
+                service.refreshToken({ refreshToken: 'expired-refresh-token' }),
+            ).rejects.toBeInstanceOf(UnauthorizedException);
+
+            expect(jwtService.verify).toHaveBeenCalledWith(
+                'expired-refresh-token',
+                { secret: 'refresh-secret' },
+            );
+            expect(usersService.findOneIncludingSystem).not.toHaveBeenCalled();
+            expect(usersService.updateRefreshToken).not.toHaveBeenCalled();
+        });
+
+        it('invalid refresh token이면 UnauthorizedException을 던진다', async () => {
+            const error = new Error('invalid token');
+            error.name = 'JsonWebTokenError';
+            jwtService.verify.mockImplementation(() => {
+                throw error;
+            });
+
+            await expect(
+                service.refreshToken({ refreshToken: 'invalid-refresh-token' }),
+            ).rejects.toBeInstanceOf(UnauthorizedException);
+
+            expect(usersService.findOneIncludingSystem).not.toHaveBeenCalled();
+            expect(usersService.updateRefreshToken).not.toHaveBeenCalled();
+        });
+
+        it('저장된 refresh token과 요청 token이 다르면 UnauthorizedException을 던진다', async () => {
+            jwtService.verify.mockReturnValue({ sub: adminUser.id });
+            usersService.findOneIncludingSystem.mockResolvedValue({
+                ...adminUser,
+                refresh_token: 'different-refresh-token',
+            } as User);
+
+            await expect(
+                service.refreshToken({ refreshToken: 'stored-refresh-token' }),
+            ).rejects.toBeInstanceOf(UnauthorizedException);
+
+            expect(usersService.findOneIncludingSystem).toHaveBeenCalledWith(
+                adminUser.id,
+            );
+            expect(jwtService.sign).not.toHaveBeenCalled();
+            expect(usersService.updateRefreshToken).not.toHaveBeenCalled();
+        });
+
+        it('사용자가 없으면 UnauthorizedException을 던진다', async () => {
+            jwtService.verify.mockReturnValue({ sub: 999 });
+            usersService.findOneIncludingSystem.mockResolvedValue(null);
+
+            await expect(
+                service.refreshToken({ refreshToken: 'stored-refresh-token' }),
+            ).rejects.toBeInstanceOf(UnauthorizedException);
+
+            expect(usersService.findOneIncludingSystem).toHaveBeenCalledWith(
+                999,
+            );
+            expect(usersService.updateRefreshToken).not.toHaveBeenCalled();
+        });
+
+        it('refresh token rotation 성공 시 새 토큰을 발급하고 새 refresh token을 저장한다', async () => {
+            jwtService.verify.mockReturnValue({ sub: adminUser.id });
+            usersService.findOneIncludingSystem.mockResolvedValue(adminUser);
+            jwtService.sign
+                .mockReturnValueOnce('rotated-access-token')
+                .mockReturnValueOnce('rotated-refresh-token');
+
+            const result = await service.refreshToken({
+                refreshToken: 'stored-refresh-token',
+            });
+
+            expect(result).toEqual({
+                accessToken: 'rotated-access-token',
+                refreshToken: 'rotated-refresh-token',
+                tokenType: 'Bearer',
+                expiresIn: 15 * 60 * 1000,
+            });
+            expect(jwtService.verify).toHaveBeenCalledWith(
+                'stored-refresh-token',
+                { secret: 'refresh-secret' },
+            );
+            expect(jwtService.sign).toHaveBeenCalledTimes(2);
+            expect(usersService.updateRefreshToken).toHaveBeenCalledWith(
+                adminUser.id,
+                'rotated-refresh-token',
+            );
+        });
+    });
+});

--- a/src/v1/auth/strategies/jwt.strategy.spec.ts
+++ b/src/v1/auth/strategies/jwt.strategy.spec.ts
@@ -1,0 +1,186 @@
+import { UnauthorizedException } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+import { Repository } from 'typeorm';
+import { Club } from '../../clubs/entities/club.entity';
+import { User } from '../../users/entities/user.entity';
+import { UsersService } from '../../users/users.service';
+import { JwtStrategy } from './jwt.strategy';
+
+type MockedUsersService = Pick<UsersService, 'findOneIncludingSystem'>;
+
+describe('JwtStrategy', () => {
+    let strategy: JwtStrategy;
+    let usersService: jest.Mocked<MockedUsersService>;
+    let clubRepository: {
+        createQueryBuilder: jest.Mock;
+    };
+    let clubQueryBuilder: {
+        where: jest.Mock;
+        andWhere: jest.Mock;
+        getOne: jest.Mock;
+    };
+
+    const adminUser = {
+        id: 1,
+        login_id: 'admin_login',
+        name: '관리자',
+        role: 'admin',
+    } as User;
+
+    const presidentUser = {
+        id: 2,
+        login_id: 'president_login',
+        name: '회장',
+        role: 'president',
+    } as User;
+
+    beforeEach(() => {
+        const configService = {
+            get: jest.fn((key: string) => {
+                if (key === 'JWT_ACCESS_SECRET') {
+                    return 'access-secret';
+                }
+
+                return undefined;
+            }),
+        } as unknown as ConfigService;
+        usersService = {
+            findOneIncludingSystem: jest.fn(),
+        };
+        clubQueryBuilder = {
+            where: jest.fn().mockReturnThis(),
+            andWhere: jest.fn().mockReturnThis(),
+            getOne: jest.fn(),
+        };
+        clubRepository = {
+            createQueryBuilder: jest.fn().mockReturnValue(clubQueryBuilder),
+        };
+
+        strategy = new JwtStrategy(
+            configService,
+            usersService as unknown as UsersService,
+            clubRepository as unknown as Repository<Club>,
+        );
+    });
+
+    it('사용자가 없으면 UnauthorizedException을 던진다', async () => {
+        usersService.findOneIncludingSystem.mockResolvedValue(null);
+
+        await expect(
+            strategy.validate({
+                sub: 999,
+                login_id: 'missing_user',
+                name: '없는 사용자',
+                role: 'admin',
+                club_id: null,
+            }),
+        ).rejects.toBeInstanceOf(UnauthorizedException);
+
+        expect(usersService.findOneIncludingSystem).toHaveBeenCalledWith(999);
+        expect(clubRepository.createQueryBuilder).not.toHaveBeenCalled();
+    });
+
+    it.each([
+        ['login_id', { login_id: 'tampered_login' }],
+        ['name', { name: '변조된 이름' }],
+        ['role', { role: 'president' }],
+    ])(
+        '%s payload가 사용자 정보와 불일치하면 UnauthorizedException을 던진다',
+        async (_, override) => {
+            usersService.findOneIncludingSystem.mockResolvedValue(adminUser);
+
+            await expect(
+                strategy.validate({
+                    sub: adminUser.id,
+                    login_id: adminUser.login_id,
+                    name: adminUser.name,
+                    role: 'admin',
+                    club_id: null,
+                    ...override,
+                }),
+            ).rejects.toBeInstanceOf(UnauthorizedException);
+
+            expect(clubRepository.createQueryBuilder).not.toHaveBeenCalled();
+        },
+    );
+
+    it('president payload의 club_id가 관리 동아리와 불일치하면 UnauthorizedException을 던진다', async () => {
+        usersService.findOneIncludingSystem.mockResolvedValue(presidentUser);
+        clubQueryBuilder.getOne.mockResolvedValue({ id: 10 } as Club);
+
+        await expect(
+            strategy.validate({
+                sub: presidentUser.id,
+                login_id: presidentUser.login_id,
+                name: presidentUser.name,
+                role: 'president',
+                club_id: 20,
+            }),
+        ).rejects.toBeInstanceOf(UnauthorizedException);
+
+        expect(clubQueryBuilder.where).toHaveBeenCalledWith(
+            'club.president_id = :userId',
+            { userId: presidentUser.id },
+        );
+        expect(clubQueryBuilder.andWhere).toHaveBeenCalledWith(
+            'club.deleted_at IS NULL',
+        );
+    });
+
+    it('일반 사용자 payload에 club_id가 포함되면 UnauthorizedException을 던진다', async () => {
+        usersService.findOneIncludingSystem.mockResolvedValue(adminUser);
+
+        await expect(
+            strategy.validate({
+                sub: adminUser.id,
+                login_id: adminUser.login_id,
+                name: adminUser.name,
+                role: 'admin',
+                club_id: 10,
+            }),
+        ).rejects.toBeInstanceOf(UnauthorizedException);
+
+        expect(clubRepository.createQueryBuilder).not.toHaveBeenCalled();
+    });
+
+    it('정상 president payload를 통과시키고 JWT의 club_id를 반환한다', async () => {
+        usersService.findOneIncludingSystem.mockResolvedValue(presidentUser);
+        clubQueryBuilder.getOne.mockResolvedValue({ id: 10 } as Club);
+
+        await expect(
+            strategy.validate({
+                sub: presidentUser.id,
+                login_id: presidentUser.login_id,
+                name: presidentUser.name,
+                role: 'president',
+                club_id: 10,
+            }),
+        ).resolves.toEqual({
+            userId: presidentUser.id,
+            login_id: presidentUser.login_id,
+            name: presidentUser.name,
+            role: presidentUser.role,
+            club_id: 10,
+        });
+    });
+
+    it('정상 일반 사용자 payload를 통과시키고 club_id null을 반환한다', async () => {
+        usersService.findOneIncludingSystem.mockResolvedValue(adminUser);
+
+        await expect(
+            strategy.validate({
+                sub: adminUser.id,
+                login_id: adminUser.login_id,
+                name: adminUser.name,
+                role: 'admin',
+                club_id: null,
+            }),
+        ).resolves.toEqual({
+            userId: adminUser.id,
+            login_id: adminUser.login_id,
+            name: adminUser.name,
+            role: adminUser.role,
+            club_id: null,
+        });
+    });
+});


### PR DESCRIPTION
### Motivation

- Auth 관련 실패 분기와 JWT payload 검증 로직을 단위 테스트로 명시적으로 검증해 인증 회귀를 줄이기 위해 작업했습니다.

### Description

- `src/v1/auth/auth.service.spec.ts` 파일을 추가해 `AuthService.login`의 사용자 없음/비밀번호 실패, 토큰 생성 성공 및 refresh token 저장 호출, 그리고 president의 `club_id` 포함 동작을 mock 기반으로 검증했습니다.
- `src/v1/auth/strategies/jwt.strategy.spec.ts` 파일을 추가해 `JwtStrategy.validate`의 사용자 없음, `login_id`/`name`/`role` 불일치, president `club_id` 불일치, 일반 사용자에 대한 `club_id` 포함 거부, 정상 payload 통과 케이스를 검증했습니다.
- 인증 범위의 테스트 존재를 반영해 `docs/evals/test-inventory.md`에 새 테스트 항목을 추가하고 `docs/evals/success-criteria.md`에 성공 기준을 기록했으며 `docs/evals/known-gaps.md`에서 이미 완료된 항목을 정리했습니다.

### Testing

- 단위 테스트: `yarn test -- auth.service.spec.ts jwt.strategy.spec.ts` 실행 결과 두 스위트 모두 통과했습니다 (both specs passed).
- 통합 검증: `npm run verify:docs && npm run type && npm test -- --runInBand`를 실행해 문서 검증·타입 검사·테스트 전체가 성공적으로 통과했습니다 (전체 테스트 통과).
- (참고) 로컬 `yarn verify:fast`는 환경의 Corepack/Yarn 설정 때문에 lockfile/installer 관련 오류가 발생해 재실행이 필요했으나, 테스트 자체는 위의 명령들로 모두 검증되었습니다.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fc0c2560808329aacd863b6505394d)