### PR TITLE
main_banners 테이블 생성 migration 추가

### DIFF
--- a/src/database/migrations/2026050700000-CreateMainBanners.ts
+++ b/src/database/migrations/2026050700000-CreateMainBanners.ts
@@ -1,0 +1,27 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class CreateMainBanners2026050700000 implements MigrationInterface {
+    name = 'CreateMainBanners2026050700000';
+
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`
+            CREATE TABLE IF NOT EXISTS main_banners (
+                id SERIAL NOT NULL,
+                image_url VARCHAR(255) NOT NULL,
+                publish_start_at TIMESTAMP WITH TIME ZONE NOT NULL,
+                publish_end_at TIMESTAMP WITH TIME ZONE NOT NULL,
+                is_active BOOLEAN NOT NULL DEFAULT TRUE,
+                created_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT now(),
+                updated_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT now(),
+                deleted_at TIMESTAMP WITH TIME ZONE,
+                CONSTRAINT "PK_main_banners_id" PRIMARY KEY (id)
+            )
+        `);
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`
+            DROP TABLE IF EXISTS main_banners
+        `);
+    }
+}


### PR DESCRIPTION
### Motivation
- 엔티티 `src/v1/main_banners/entities/main_banner.entity.ts`와 동일한 스키마로 DB에 `main_banners` 테이블을 생성하기 위해 migration을 추가했습니다.

### Description
- 새 migration 파일 `src/database/migrations/2026050700000-CreateMainBanners.ts`를 추가하여 `id`, `image_url`, `publish_start_at`, `publish_end_at`, `is_active`, `created_at`, `updated_at`, `deleted_at` 컬럼과 기본키 제약을 생성합니다.
- `up()`은 `CREATE TABLE IF NOT EXISTS main_banners (...)`를 실행하고 `down()`은 `DROP TABLE IF EXISTS main_banners`로 롤백합니다.
- 엔티티 정의와 일치하도록 `created_at`/`updated_at`에 `now()` 기본값을 사용하고 `deleted_at`은 nullable로 설정했습니다.

### Testing
- `yarn build`가 성공적으로 완료되었습니다.
- `yarn migration:check`가 새 migration을 감지하여 실행 환경에서 인식함을 확인했습니다.
- `yarn verify:fast` 실행 시 Jest 테스트 스위트가 통과하여 `Test Suites: 9 passed, 9 total`로 완료되었습니다.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fc23ae46208329a45904106476df03)