### PR TITLE
test: 메인 배너 계약 테스트 추가 및 findActive 필터 보강

### DIFF
--- a/docs/evals/success-criteria.md
+++ b/docs/evals/success-criteria.md
@@ -55,6 +55,32 @@
 - [club_reports.service.spec.ts](../../src/v1/club_reports/club_reports.service.spec.ts)
 - [club_reports.controller.spec.ts](../../src/v1/club_reports/club_reports.controller.spec.ts)
 
+## Main Banners
+
+### 메인 배너 관리
+
+- 메인 배너 생성은 `image_url`, `publish_start_at`, `publish_end_at`, `is_active` 필수값을 검증하고 저장 payload로 변환해야 한다.
+- 메인 배너 수정은 삭제되지 않은 기존 배너만 갱신하고, 대상이 없으면 Bad Request로 거부해야 한다.
+- 메인 배너 삭제는 삭제되지 않은 기존 배너만 soft delete 처리하고, 대상이 없으면 Bad Request로 거부해야 한다.
+- 활성 목록 조회는 삭제되지 않고 `is_active`가 true이며 현재 시간이 공개 시작일과 종료일 사이에 있는 배너만 최신 공개 시작일 순으로 반환해야 한다.
+- 날짜 입력은 날짜만 있는 값, 분/초 단위 날짜-시간, 명시적 timezone 값을 지원하고 timezone이 없으면 Seoul 기준으로 파싱해야 한다.
+- 날짜 형식이 올바르지 않거나 공개 시작일이 종료일과 같거나 늦으면 Bad Request로 거부해야 한다.
+- `is_active`는 boolean 타입만 허용해야 한다.
+
+관련 테스트:
+
+- [main_banners.service.spec.ts](../../src/v1/main_banners/main_banners.service.spec.ts)
+
+### 메인 배너 이미지 업로드
+
+- 이미지 업로드 controller는 `file` 누락을 Bad Request로 거부해야 한다.
+- 이미지 업로드 controller는 `image/jpeg`, `image/png`, `image/webp`만 허용하고 그 외 MIME은 Bad Request로 거부해야 한다.
+- 정상 이미지 업로드는 S3 업로드 결과를 `image_url` payload로 반환해야 한다.
+
+관련 테스트:
+
+- [main_banners.controller.spec.ts](../../src/v1/main_banners/main_banners.controller.spec.ts)
+
 ## Auth
 
 ### 로그인과 refresh token

--- a/docs/evals/test-inventory.md
+++ b/docs/evals/test-inventory.md
@@ -19,6 +19,8 @@
 | users        | [users.controller.spec.ts](../../src/v1/users/users.controller.spec.ts)                      | code-graded | 사용자 controller 계약                             |
 | club reports | [club_reports.service.spec.ts](../../src/v1/club_reports/club_reports.service.spec.ts)       | code-graded | 활동보고서 service 계약                            |
 | club reports | [club_reports.controller.spec.ts](../../src/v1/club_reports/club_reports.controller.spec.ts) | code-graded | 활동보고서 controller 계약                         |
+| main banners | [main_banners.service.spec.ts](../../src/v1/main_banners/main_banners.service.spec.ts)       | code-graded | 메인 배너 service 생성/수정/삭제/활성 목록/검증 계약 |
+| main banners | [main_banners.controller.spec.ts](../../src/v1/main_banners/main_banners.controller.spec.ts) | code-graded | 메인 배너 이미지 업로드 controller 계약            |
 | auth         | [auth.service.spec.ts](../../src/v1/auth/auth.service.spec.ts)                               | code-graded | 로그인 실패/성공, refresh token 실패/rotation 계약 |
 | auth         | [jwt.strategy.spec.ts](../../src/v1/auth/strategies/jwt.strategy.spec.ts)                    | code-graded | JWT payload 사용자 정보/club_id 검증 계약          |
 

--- a/src/v1/main_banners/main_banners.controller.spec.ts
+++ b/src/v1/main_banners/main_banners.controller.spec.ts
@@ -1,0 +1,72 @@
+import { HttpStatus } from '@nestjs/common';
+import { S3Service } from '../../common/lib/s3-uploads';
+import { MainBannersController } from './main_banners.controller';
+import { MainBannersService } from './main_banners.service';
+
+describe('MainBannersController', () => {
+    let controller: MainBannersController;
+    let s3Service: jest.Mocked<Pick<S3Service, 'upload'>>;
+
+    beforeEach(() => {
+        s3Service = {
+            upload: jest.fn(),
+        };
+
+        controller = new MainBannersController(
+            {} as MainBannersService,
+            s3Service as unknown as S3Service,
+        );
+    });
+
+    describe('uploadImage', () => {
+        const file = (mimetype: string): Express.Multer.File =>
+            ({
+                buffer: Buffer.from('banner-image'),
+                mimetype,
+                originalname: 'banner.webp',
+            }) as Express.Multer.File;
+
+        it('file이 없으면 Bad Request를 던지고 S3를 호출하지 않는다', async () => {
+            await expect(
+                controller.uploadImage(
+                    undefined as unknown as Express.Multer.File,
+                ),
+            ).rejects.toMatchObject({
+                status: HttpStatus.BAD_REQUEST,
+                message: '파일이 필요합니다.',
+            });
+            expect(s3Service.upload).not.toHaveBeenCalled();
+        });
+
+        it('허용되지 않는 MIME이면 Bad Request를 던지고 S3를 호출하지 않는다', async () => {
+            await expect(
+                controller.uploadImage(file('image/gif')),
+            ).rejects.toMatchObject({
+                status: HttpStatus.BAD_REQUEST,
+                message: '허용되지 않는 이미지 형식입니다. (jpg, png, webp)',
+            });
+            expect(s3Service.upload).not.toHaveBeenCalled();
+        });
+
+        it.each(['image/jpeg', 'image/png', 'image/webp'])(
+            '%s 이미지는 S3에 업로드하고 image_url payload를 반환한다',
+            async (mimetype) => {
+                s3Service.upload.mockResolvedValue(
+                    `https://cdn.example.com/main-banners/${mimetype}`,
+                );
+                const uploadFile = file(mimetype);
+
+                const result = await controller.uploadImage(uploadFile);
+
+                expect(s3Service.upload).toHaveBeenCalledWith(
+                    uploadFile.buffer,
+                    'main-banners',
+                    mimetype,
+                );
+                expect(result).toEqual({
+                    image_url: `https://cdn.example.com/main-banners/${mimetype}`,
+                });
+            },
+        );
+    });
+});

--- a/src/v1/main_banners/main_banners.service.spec.ts
+++ b/src/v1/main_banners/main_banners.service.spec.ts
@@ -1,0 +1,254 @@
+import { HttpException, HttpStatus } from '@nestjs/common';
+import { FindOperator, Repository, UpdateResult } from 'typeorm';
+import { MainBanner } from './entities/main_banner.entity';
+import { MainBannersService } from './main_banners.service';
+
+const seoulDate = (value: string) => new Date(`${value}+09:00`);
+
+describe('MainBannersService', () => {
+    let service: MainBannersService;
+    let repository: {
+        create: jest.Mock;
+        save: jest.Mock;
+        update: jest.Mock;
+        findOne: jest.Mock;
+        find: jest.Mock;
+    };
+
+    const validDto = {
+        image_url: 'https://cdn.example.com/banner.webp',
+        publish_start_at: '2026-05-01 09:00:00',
+        publish_end_at: '2026-05-31 23:59:59',
+        is_active: true,
+    };
+
+    beforeEach(() => {
+        repository = {
+            create: jest.fn((payload) => ({ id: 1, ...payload })),
+            save: jest.fn(async (banner) => ({ ...banner })),
+            update: jest.fn(),
+            findOne: jest.fn(),
+            find: jest.fn(),
+        };
+
+        service = new MainBannersService(
+            repository as unknown as Repository<MainBanner>,
+        );
+    });
+
+    describe('create', () => {
+        it('필수값과 날짜를 검증한 뒤 Seoul 기준 Date payload를 저장한다', async () => {
+            const result = await service.create(validDto);
+
+            const expectedPayload = {
+                image_url: validDto.image_url,
+                publish_start_at: seoulDate('2026-05-01T09:00:00'),
+                publish_end_at: seoulDate('2026-05-31T23:59:59'),
+                is_active: true,
+            };
+
+            expect(repository.create).toHaveBeenCalledWith(expectedPayload);
+            expect(repository.save).toHaveBeenCalledWith({
+                id: 1,
+                ...expectedPayload,
+            });
+            expect(result).toEqual({ id: 1, ...expectedPayload });
+        });
+
+        it('날짜만 입력되면 Seoul 자정 기준 Date payload로 변환한다', async () => {
+            await service.create({
+                ...validDto,
+                publish_start_at: '2026-05-01',
+                publish_end_at: '2026-05-02',
+            });
+
+            expect(repository.create).toHaveBeenCalledWith(
+                expect.objectContaining({
+                    publish_start_at: seoulDate('2026-05-01T00:00:00'),
+                    publish_end_at: seoulDate('2026-05-02T00:00:00'),
+                }),
+            );
+        });
+
+        it('명시적인 timezone이 있으면 입력 timezone 그대로 Date payload로 변환한다', async () => {
+            await service.create({
+                ...validDto,
+                publish_start_at: '2026-05-01T00:00:00Z',
+                publish_end_at: '2026-05-02T00:00:00Z',
+            });
+
+            expect(repository.create).toHaveBeenCalledWith(
+                expect.objectContaining({
+                    publish_start_at: new Date('2026-05-01T00:00:00Z'),
+                    publish_end_at: new Date('2026-05-02T00:00:00Z'),
+                }),
+            );
+        });
+
+        it.each([
+            [
+                'image_url',
+                { ...validDto, image_url: '   ' },
+                'image_url은 필수입니다.',
+            ],
+            [
+                'publish_start_at',
+                { ...validDto, publish_start_at: '' },
+                '공개 시작일과 종료일은 필수입니다.',
+            ],
+            [
+                'publish_end_at',
+                { ...validDto, publish_end_at: '   ' },
+                '공개 시작일과 종료일은 필수입니다.',
+            ],
+        ])(
+            '%s 필수값이 없으면 Bad Request를 던진다',
+            async (_field, dto, message) => {
+                await expect(service.create(dto)).rejects.toMatchObject({
+                    status: HttpStatus.BAD_REQUEST,
+                    message,
+                });
+                expect(repository.create).not.toHaveBeenCalled();
+                expect(repository.save).not.toHaveBeenCalled();
+            },
+        );
+
+        it('날짜 형식이 올바르지 않으면 Bad Request를 던진다', async () => {
+            await expect(
+                service.create({
+                    ...validDto,
+                    publish_start_at: 'invalid-date',
+                }),
+            ).rejects.toMatchObject({
+                status: HttpStatus.BAD_REQUEST,
+                message: '날짜 형식이 올바르지 않습니다.',
+            });
+        });
+
+        it('시작일이 종료일과 같거나 늦으면 Bad Request를 던진다', async () => {
+            await expect(
+                service.create({
+                    ...validDto,
+                    publish_start_at: '2026-05-31 23:59:59',
+                    publish_end_at: '2026-05-31 23:59:59',
+                }),
+            ).rejects.toMatchObject({
+                status: HttpStatus.BAD_REQUEST,
+                message: '공개 시작일은 종료일보다 이전이어야 합니다.',
+            });
+
+            await expect(
+                service.create({
+                    ...validDto,
+                    publish_start_at: '2026-06-01 00:00:00',
+                    publish_end_at: '2026-05-31 23:59:59',
+                }),
+            ).rejects.toMatchObject({
+                status: HttpStatus.BAD_REQUEST,
+                message: '공개 시작일은 종료일보다 이전이어야 합니다.',
+            });
+        });
+
+        it('is_active가 boolean이 아니면 Bad Request를 던진다', async () => {
+            await expect(
+                service.create({
+                    ...validDto,
+                    is_active: 'true' as unknown as boolean,
+                }),
+            ).rejects.toMatchObject({
+                status: HttpStatus.BAD_REQUEST,
+                message: 'is_active는 boolean 타입이어야 합니다.',
+            });
+        });
+    });
+
+    describe('update', () => {
+        it('존재하는 배너를 수정한 뒤 수정된 단건을 반환한다', async () => {
+            const updatedBanner = { id: 7, image_url: validDto.image_url };
+            repository.update.mockResolvedValue({ affected: 1 } as UpdateResult);
+            repository.findOne.mockResolvedValue(updatedBanner);
+
+            const result = await service.update(7, validDto);
+
+            expect(repository.update).toHaveBeenCalledWith(
+                expect.objectContaining({ id: 7 }),
+                expect.objectContaining({ image_url: validDto.image_url }),
+            );
+            expect(repository.findOne).toHaveBeenCalledWith({
+                where: expect.objectContaining({ id: 7 }),
+            });
+            expect(result).toBe(updatedBanner);
+        });
+
+        it('수정 대상이 없으면 Bad Request를 던진다', async () => {
+            repository.update.mockResolvedValue({ affected: 0 } as UpdateResult);
+
+            await expect(service.update(404, validDto)).rejects.toMatchObject({
+                status: HttpStatus.BAD_REQUEST,
+                message: '해당 배너가 존재하지 않습니다.',
+            });
+            expect(repository.findOne).not.toHaveBeenCalled();
+        });
+    });
+
+    describe('remove', () => {
+        it('존재하는 배너를 soft delete 처리한다', async () => {
+            const updateResult = { affected: 1 } as UpdateResult;
+            repository.update.mockResolvedValue(updateResult);
+
+            const result = await service.remove(7);
+
+            expect(repository.update).toHaveBeenCalledWith(
+                expect.objectContaining({ id: 7 }),
+                { deleted_at: expect.any(Date) },
+            );
+            expect(result).toBe(updateResult);
+        });
+
+        it('삭제 대상이 없으면 Bad Request를 던진다', async () => {
+            repository.update.mockResolvedValue({ affected: 0 } as UpdateResult);
+
+            const promise = service.remove(404);
+            await expect(promise).rejects.toBeInstanceOf(HttpException);
+            await expect(promise).rejects.toMatchObject({
+                status: HttpStatus.BAD_REQUEST,
+                message: '해당 배너가 존재하지 않습니다.',
+            });
+        });
+    });
+
+    describe('findActive', () => {
+        beforeEach(() => {
+            jest.useFakeTimers().setSystemTime(new Date('2026-05-07T12:00:00Z'));
+        });
+
+        afterEach(() => {
+            jest.useRealTimers();
+        });
+
+        it('삭제되지 않고 활성화되어 있으며 현재 공개 기간에 포함된 배너를 최신 시작일 순으로 조회한다', async () => {
+            const activeBanners = [{ id: 1 }, { id: 2 }];
+            repository.find.mockResolvedValue(activeBanners);
+
+            const result = await service.findActive();
+
+            const findOptions = repository.find.mock.calls[0][0];
+            expect(findOptions.where).toEqual(
+                expect.objectContaining({
+                    deleted_at: expect.any(FindOperator),
+                    is_active: true,
+                    publish_start_at: expect.any(FindOperator),
+                    publish_end_at: expect.any(FindOperator),
+                }),
+            );
+            expect(findOptions.where.publish_start_at.value).toEqual(
+                new Date('2026-05-07T12:00:00Z'),
+            );
+            expect(findOptions.where.publish_end_at.value).toEqual(
+                new Date('2026-05-07T12:00:00Z'),
+            );
+            expect(findOptions.order).toEqual({ publish_start_at: 'DESC' });
+            expect(result).toBe(activeBanners);
+        });
+    });
+});

--- a/src/v1/main_banners/main_banners.service.ts
+++ b/src/v1/main_banners/main_banners.service.ts
@@ -1,6 +1,6 @@
 import { HttpException, HttpStatus, Injectable } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
-import { IsNull, Repository } from 'typeorm';
+import { IsNull, LessThanOrEqual, MoreThanOrEqual, Repository } from 'typeorm';
 import { MainBanner } from './entities/main_banner.entity';
 import { UpsertMainBannerDto } from './dto/upsert-main-banner.dto';
 
@@ -54,9 +54,14 @@ export class MainBannersService {
     }
 
     async findActive() {
+        const now = new Date();
+
         return await this.mainBannerRepository.find({
             where: {
                 deleted_at: IsNull(),
+                is_active: true,
+                publish_start_at: LessThanOrEqual(now),
+                publish_end_at: MoreThanOrEqual(now),
             },
             order: {
                 publish_start_at: 'DESC',


### PR DESCRIPTION
### Motivation
- 메인 배너 도메인의 성공 기준을 문서화하고 생성/수정/삭제/활성 목록/날짜 파싱/필수값/is_active 검증을 명시적으로 테스트로 옮기기 위해 변경했습니다. 
- 이미지 업로드 controller 계약을 S3 mock 기반으로 검증해 파일 누락, MIME 거부, 정상 업로드 흐름을 보호하려 했습니다.

### Description
- `docs/evals/success-criteria.md`에 Main Banners 섹션을 추가하고 관련 성공 기준(필수 필드, 날짜 파싱 규칙, 활성 조회 조건, `is_active` 타입 등)을 기록했습니다. 
- `docs/evals/test-inventory.md`에 `src/v1/main_banners/main_banners.service.spec.ts`와 `src/v1/main_banners/main_banners.controller.spec.ts` 항목을 추가했습니다. 
- `src/v1/main_banners/main_banners.service.ts`의 `findActive`를 보강해 `is_active: true` 및 현재 시간이 `publish_start_at`/`publish_end_at` 범위에 있는 항목만 조회하도록 `LessThanOrEqual`/`MoreThanOrEqual` 조건을 추가했습니다. 
- Jest 테스트를 추가해 `create`/`update`/`remove`/`findActive`와 날짜 파싱(Seoul 기준 보정 포함), 시작일/종료일 역전, `is_active` 타입 검증을 `src/v1/main_banners/main_banners.service.spec.ts`에서 검증하고, 이미지 업로드 controller는 S3를 mock 처리하여 `file` 누락, 허용되지 않는 MIME, 정상 업로드 payload를 `src/v1/main_banners/main_banners.controller.spec.ts`로 검증했습니다. 

### Testing
- 문서 계약 검증은 `node scripts/check-doc-contracts.mjs`로 통과했습니다. 
- 타입 검사 및 단위 테스트는 `./node_modules/.bin/tsc --noEmit -p tsconfig.json` 및 `./node_modules/.bin/jest --runInBand` 명령으로 실행했으며 테스트 스위트 전체가 통과했습니다 (`Test Suites: 11 passed, Tests: 42 passed`). 
- 주의: `yarn verify:fast`는 현재 환경에서 Yarn 4가 기존 v1 `yarn.lock` 워크스페이스 인식 문제로 실패하는 현상이 있어 CI 환경에서의 `yarn` 실행은 환경에 따라 실패할 수 있음을 남깁니다.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fc289cb9d88329bc3cefe5584dd780)