### PR TITLE
Club schedules: remove route-injected club_id from DTO, add length limits, scope updates/deletes by club via query builder, and update tests/docs

### DIFF
--- a/docs/evals/success-criteria.md
+++ b/docs/evals/success-criteria.md
@@ -79,6 +79,7 @@
 ### 일정 관리
 
 - 일정 생성은 `title`, `type`, `start_at`, `end_at`, `is_public` 필수값을 검증하고 저장 payload로 변환해야 한다.
+- `title`과 `location`은 DB 길이 제약과 같이 100자를 넘지 않아야 한다.
 - 일정 선택값은 `location`, `description`, `external_url`만 허용하며 `external_url`이 없거나 공백이면 `null`로 정규화해야 한다.
 - 일정 생성과 수정은 `external_url` 값이 있으면 문자열 타입만 허용하고 2048자를 넘지 않아야 한다.
 - 일정 유형은 `recruitment`, `event`, `regular_meeting`, `notice`만 허용해야 한다.
@@ -86,9 +87,9 @@
 - 날짜 형식이 올바르지 않거나 시작일시가 종료일시와 같거나 늦으면 Bad Request로 거부해야 한다.
 - 회장은 본인이 관리하는 동아리 일정만 조회, 생성, 수정, 삭제할 수 있어야 한다.
 - 회장 목록 조회는 전체, 공개, 비공개, 다가오는 일정, 지난 일정 필터를 지원해야 한다.
-- 사용자 공개 조회는 삭제되지 않고 공개 상태인 일정만 반환해야 한다.
+- 사용자 공개 조회는 삭제되지 않고 공개 상태인 일정만 반환하며, soft delete 된 동아리의 일정은 제외해야 한다.
 - 관리자는 전체 일정 목록과 캘린더 범위 조회를 할 수 있고, 일정 내용을 직접 수정하지 않고 공개 상태 변경과 soft delete만 수행해야 한다.
-- DTO에는 첨부 이미지나 신청 링크에 해당하는 필드를 두지 않아야 한다.
+- DTO에는 route에서 주입되는 `club_id`, 첨부 이미지, 신청 링크에 해당하는 필드를 두지 않아야 한다.
 
 관련 테스트:
 
@@ -164,7 +165,7 @@
 - `UpsertMainBannerDto`는 `image_url`, `publish_start_at`, `publish_end_at`을 필수 문자열로 받고 `is_active`를 필수 boolean으로 받아야 한다.
 - auth 요청 DTO는 `LoginDto.login_id`, `LoginDto.password`, `RefreshTokenDto.refreshToken`, `VerifyTokenDto.token`을 필수 문자열로 받아야 한다.
 - `CreateClubReportDto`는 route parameter에서 주입되는 `club_id`를 선택 number로 두고, `title`, `content`, `image_urls`를 각각 필수 문자열/문자열 배열로 검증해야 한다.
-- `CreateClubScheduleDto`는 route parameter에서 주입되는 `club_id`를 선택 number로 두고, `title`, `type`, `start_at`, `end_at`, `is_public`을 필수값으로 검증하며 선택 필드는 `location`, `description`, `external_url`만 허용해야 한다.
+- `CreateClubScheduleDto`는 route parameter에서 주입되는 `club_id`를 body 필드로 받지 않고, `title`, `type`, `start_at`, `end_at`, `is_public`을 필수값으로 검증하며 선택 필드는 `location`, `description`, `external_url`만 허용해야 한다.
 - `UpdateClubScheduleDto`는 `CreateClubScheduleDto`의 모든 필드를 선택 필드로 만들되 타입 규칙을 유지해야 한다.
 - 일정 관리자 상태 DTO는 `is_public`을 필수 boolean으로 받아야 하며, 일정 query DTO는 선언된 필터 타입을 유지해야 한다.
 - DTO에는 persistence 전용 TypeORM column metadata를 두지 않고 entity에만 유지해야 한다.

--- a/src/v1/club_schedules/club_schedules.service.spec.ts
+++ b/src/v1/club_schedules/club_schedules.service.spec.ts
@@ -16,6 +16,7 @@ describe('ClubSchedulesService', () => {
         createQueryBuilder: jest.Mock;
     };
     let queryBuilder: {
+        leftJoin: jest.Mock;
         leftJoinAndSelect: jest.Mock;
         where: jest.Mock;
         andWhere: jest.Mock;
@@ -49,6 +50,7 @@ describe('ClubSchedulesService', () => {
 
     beforeEach(() => {
         queryBuilder = {
+            leftJoin: jest.fn().mockReturnThis(),
             leftJoinAndSelect: jest.fn().mockReturnThis(),
             where: jest.fn().mockReturnThis(),
             andWhere: jest.fn().mockReturnThis(),
@@ -176,13 +178,19 @@ describe('ClubSchedulesService', () => {
 
     describe('findPublicByClubId', () => {
         it('사용자용 공개 일정은 공개, 일정 미삭제, 동아리 미삭제 조건으로 조회한다', async () => {
-            queryBuilder.getMany.mockResolvedValue([schedule]);
+            const publicSchedule = { id: 7, title: '정기 모임' };
+            queryBuilder.getMany.mockResolvedValue([publicSchedule]);
 
             const result = await service.findPublicByClubId(1);
 
             expect(repository.createQueryBuilder).toHaveBeenCalledWith(
                 'schedule',
             );
+            expect(queryBuilder.leftJoin).toHaveBeenCalledWith(
+                'schedule.club',
+                'club',
+            );
+            expect(queryBuilder.leftJoinAndSelect).not.toHaveBeenCalled();
             expect(queryBuilder.andWhere).toHaveBeenCalledWith(
                 'schedule.is_public = :isPublic',
                 { isPublic: true },
@@ -190,7 +198,8 @@ describe('ClubSchedulesService', () => {
             expect(queryBuilder.andWhere).toHaveBeenCalledWith(
                 'club.deleted_at IS NULL',
             );
-            expect(result).toEqual([schedule]);
+            expect(result).toEqual([publicSchedule]);
+            expect(result[0]).not.toHaveProperty('club');
         });
     });
 

--- a/src/v1/club_schedules/club_schedules.service.spec.ts
+++ b/src/v1/club_schedules/club_schedules.service.spec.ts
@@ -21,6 +21,9 @@ describe('ClubSchedulesService', () => {
         andWhere: jest.Mock;
         orderBy: jest.Mock;
         getMany: jest.Mock;
+        update: jest.Mock;
+        set: jest.Mock;
+        execute: jest.Mock;
     };
 
     const validDto = {
@@ -51,6 +54,9 @@ describe('ClubSchedulesService', () => {
             andWhere: jest.fn().mockReturnThis(),
             orderBy: jest.fn().mockReturnThis(),
             getMany: jest.fn(),
+            update: jest.fn().mockReturnThis(),
+            set: jest.fn().mockReturnThis(),
+            execute: jest.fn(),
         };
         repository = {
             create: jest.fn((payload) => ({ id: 1, ...payload })),
@@ -169,18 +175,21 @@ describe('ClubSchedulesService', () => {
     });
 
     describe('findPublicByClubId', () => {
-        it('사용자용 공개 일정은 공개, 미삭제 조건으로 조회한다', async () => {
-            repository.find.mockResolvedValue([schedule]);
+        it('사용자용 공개 일정은 공개, 일정 미삭제, 동아리 미삭제 조건으로 조회한다', async () => {
+            queryBuilder.getMany.mockResolvedValue([schedule]);
 
             const result = await service.findPublicByClubId(1);
 
-            expect(repository.find).toHaveBeenCalledWith({
-                where: expect.objectContaining({
-                    club: { id: 1 },
-                    is_public: true,
-                }),
-                order: { start_at: 'ASC' },
-            });
+            expect(repository.createQueryBuilder).toHaveBeenCalledWith(
+                'schedule',
+            );
+            expect(queryBuilder.andWhere).toHaveBeenCalledWith(
+                'schedule.is_public = :isPublic',
+                { isPublic: true },
+            );
+            expect(queryBuilder.andWhere).toHaveBeenCalledWith(
+                'club.deleted_at IS NULL',
+            );
             expect(result).toEqual([schedule]);
         });
     });
@@ -192,7 +201,7 @@ describe('ClubSchedulesService', () => {
                 ...schedule,
                 title: '변경된 일정',
             });
-            repository.update.mockResolvedValue({
+            queryBuilder.execute.mockResolvedValue({
                 affected: 1,
             } as UpdateResult);
 
@@ -201,12 +210,14 @@ describe('ClubSchedulesService', () => {
                 external_url: ' ',
             });
 
-            expect(repository.update).toHaveBeenCalledWith(
-                expect.objectContaining({ id: 7 }),
-                {
-                    title: '변경된 일정',
-                    external_url: null,
-                },
+            expect(queryBuilder.update).toHaveBeenCalledWith(ClubSchedule);
+            expect(queryBuilder.set).toHaveBeenCalledWith({
+                title: '변경된 일정',
+                external_url: null,
+            });
+            expect(queryBuilder.andWhere).toHaveBeenCalledWith(
+                'club_id = :clubId',
+                { clubId: 1 },
             );
             expect(result.title).toBe('변경된 일정');
         });
@@ -217,7 +228,28 @@ describe('ClubSchedulesService', () => {
             await expect(
                 service.update(1, 404, { title: '변경' }),
             ).rejects.toBeInstanceOf(NotFoundException);
-            expect(repository.update).not.toHaveBeenCalled();
+            expect(queryBuilder.execute).not.toHaveBeenCalled();
+        });
+    });
+
+    describe('removeByClubId', () => {
+        it('본인 동아리 일정만 club_id 조건으로 soft delete 처리한다', async () => {
+            repository.findOne.mockResolvedValue(schedule);
+            queryBuilder.execute.mockResolvedValue({
+                affected: 1,
+            } as UpdateResult);
+
+            const result = await service.removeByClubId(1, 7);
+
+            expect(queryBuilder.update).toHaveBeenCalledWith(ClubSchedule);
+            expect(queryBuilder.set).toHaveBeenCalledWith({
+                deleted_at: expect.any(Date),
+            });
+            expect(queryBuilder.andWhere).toHaveBeenCalledWith(
+                'club_id = :clubId',
+                { clubId: 1 },
+            );
+            expect(result).toEqual({ affected: 1 });
         });
     });
 

--- a/src/v1/club_schedules/club_schedules.service.ts
+++ b/src/v1/club_schedules/club_schedules.service.ts
@@ -87,7 +87,7 @@ export class ClubSchedulesService {
     async findPublicByClubId(clubId: number) {
         return await this.clubScheduleRepository
             .createQueryBuilder('schedule')
-            .leftJoinAndSelect('schedule.club', 'club')
+            .leftJoin('schedule.club', 'club')
             .where('schedule.club_id = :clubId', { clubId })
             .andWhere('schedule.deleted_at IS NULL')
             .andWhere('schedule.is_public = :isPublic', { isPublic: true })

--- a/src/v1/club_schedules/club_schedules.service.ts
+++ b/src/v1/club_schedules/club_schedules.service.ts
@@ -12,6 +12,7 @@ import {
     Repository,
     SelectQueryBuilder,
 } from 'typeorm';
+import { QueryDeepPartialEntity } from 'typeorm/query-builder/QueryPartialEntity';
 import {
     parseSeoulDateTime,
     validateDateRange,
@@ -84,16 +85,15 @@ export class ClubSchedulesService {
     }
 
     async findPublicByClubId(clubId: number) {
-        return await this.clubScheduleRepository.find({
-            where: {
-                club: { id: clubId },
-                deleted_at: IsNull(),
-                is_public: true,
-            },
-            order: {
-                start_at: 'ASC',
-            },
-        });
+        return await this.clubScheduleRepository
+            .createQueryBuilder('schedule')
+            .leftJoinAndSelect('schedule.club', 'club')
+            .where('schedule.club_id = :clubId', { clubId })
+            .andWhere('schedule.deleted_at IS NULL')
+            .andWhere('schedule.is_public = :isPublic', { isPublic: true })
+            .andWhere('club.deleted_at IS NULL')
+            .orderBy('schedule.start_at', 'ASC')
+            .getMany();
     }
 
     async update(
@@ -111,17 +111,14 @@ export class ClubSchedulesService {
             );
         }
 
-        await this.clubScheduleRepository.update(
-            { id: scheduleId, deleted_at: IsNull() },
-            payload,
-        );
+        await this.updateOwnedSchedule(clubId, scheduleId, payload);
 
         return await this.findOwnedSchedule(clubId, scheduleId);
     }
 
     async removeByClubId(clubId: number, scheduleId: number) {
         await this.findOwnedSchedule(clubId, scheduleId);
-        return await this.softDelete(scheduleId);
+        return await this.softDeleteOwned(clubId, scheduleId);
     }
 
     async findAllForAdmin(query: ClubScheduleAdminQueryDto = {}) {
@@ -201,6 +198,32 @@ export class ClubSchedulesService {
         }
 
         return schedule;
+    }
+
+    private async updateOwnedSchedule(
+        clubId: number,
+        scheduleId: number,
+        payload: QueryDeepPartialEntity<ClubSchedule>,
+    ) {
+        return await this.clubScheduleRepository
+            .createQueryBuilder()
+            .update(ClubSchedule)
+            .set(payload)
+            .where('id = :scheduleId', { scheduleId })
+            .andWhere('club_id = :clubId', { clubId })
+            .andWhere('deleted_at IS NULL')
+            .execute();
+    }
+
+    private async softDeleteOwned(clubId: number, scheduleId: number) {
+        return await this.clubScheduleRepository
+            .createQueryBuilder()
+            .update(ClubSchedule)
+            .set({ deleted_at: new Date() })
+            .where('id = :scheduleId', { scheduleId })
+            .andWhere('club_id = :clubId', { clubId })
+            .andWhere('deleted_at IS NULL')
+            .execute();
     }
 
     private async softDelete(scheduleId: number) {
@@ -294,7 +317,7 @@ export class ClubSchedulesService {
         dto: UpdateClubScheduleDto,
         schedule: ClubSchedule,
     ) {
-        const payload: Record<string, unknown> = {};
+        const payload: QueryDeepPartialEntity<ClubSchedule> = {};
 
         if (dto.title !== undefined) {
             if (!dto.title.trim()) {

--- a/src/v1/club_schedules/dto/create-club-schedule.dto.ts
+++ b/src/v1/club_schedules/dto/create-club-schedule.dto.ts
@@ -1,7 +1,6 @@
 import {
     IsBoolean,
     IsIn,
-    IsNumber,
     IsOptional,
     IsString,
     MaxLength,
@@ -12,11 +11,8 @@ import {
 } from '../entities/club_schedule.entity';
 
 export class CreateClubScheduleDto {
-    @IsOptional()
-    @IsNumber()
-    club_id?: number;
-
     @IsString()
+    @MaxLength(100)
     title: string;
 
     @IsIn(CLUB_SCHEDULE_TYPES)
@@ -33,6 +29,7 @@ export class CreateClubScheduleDto {
 
     @IsOptional()
     @IsString()
+    @MaxLength(100)
     location?: string;
 
     @IsOptional()

--- a/src/v1/clubs/clubs.controller.spec.ts
+++ b/src/v1/clubs/clubs.controller.spec.ts
@@ -149,7 +149,7 @@ describe('ClubsController', () => {
             expect(result).toBe(schedules);
         });
 
-        it('회장용 일정 생성은 route club_id를 주입해 service에 위임한다', async () => {
+        it('회장용 일정 생성은 route clubId로 service에 위임한다', async () => {
             const dto: CreateClubScheduleDto = {
                 title: '정기 모임',
                 type: 'regular_meeting' as const,
@@ -165,7 +165,6 @@ describe('ClubsController', () => {
                 presidentRequest,
             );
 
-            expect(dto.club_id).toBe(1);
             expect(clubSchedulesService.create).toHaveBeenCalledWith(1, dto);
             expect(result).toEqual({ id: 1 });
         });
@@ -207,11 +206,9 @@ describe('ClubsController', () => {
                 controller.deleteSchedule(1, 7, presidentRequest),
             ).resolves.toEqual({ affected: 1 });
 
-            expect(clubSchedulesService.update).toHaveBeenCalledWith(
-                1,
-                7,
-                expect.objectContaining({ title: '변경', club_id: 1 }),
-            );
+            expect(clubSchedulesService.update).toHaveBeenCalledWith(1, 7, {
+                title: '변경',
+            });
             expect(clubSchedulesService.removeByClubId).toHaveBeenCalledWith(
                 1,
                 7,

--- a/src/v1/clubs/clubs.controller.ts
+++ b/src/v1/clubs/clubs.controller.ts
@@ -151,7 +151,6 @@ export class ClubsController {
         @Request() req,
     ) {
         this.assertClubWritePermission(req, Number(clubId));
-        dto.club_id = Number(clubId);
         return await this.clubSchedulesService.create(Number(clubId), dto);
     }
 
@@ -165,7 +164,6 @@ export class ClubsController {
         @Request() req,
     ) {
         this.assertClubWritePermission(req, Number(clubId));
-        dto.club_id = Number(clubId);
         return await this.clubSchedulesService.update(
             Number(clubId),
             Number(scheduleId),

--- a/src/v1/dto-validation.spec.ts
+++ b/src/v1/dto-validation.spec.ts
@@ -267,7 +267,6 @@ describe('DTO runtime validation rules', () => {
                 new CreateClubScheduleDto(),
             );
             const invalidErrors = validatePlain(CreateClubScheduleDto, {
-                club_id: '1',
                 title: 1,
                 type: 'etc',
                 start_at: true,
@@ -288,7 +287,6 @@ describe('DTO runtime validation rules', () => {
             );
             expect(invalidErrors.map((error) => error.property)).toEqual(
                 expect.arrayContaining([
-                    'club_id',
                     'title',
                     'type',
                     'start_at',
@@ -309,6 +307,7 @@ describe('DTO runtime validation rules', () => {
                     location: '학생회관',
                     description: '설명',
                     external_url: 'https://forms.example.com/schedule',
+                    club_id: 1,
                     image_url: 'https://example.com/image.png',
                 }),
             ).rejects.toBeInstanceOf(BadRequestException);
@@ -331,13 +330,21 @@ describe('DTO runtime validation rules', () => {
             expect(validateSync(new UpdateClubScheduleDto())).toHaveLength(0);
 
             const errors = validatePlain(UpdateClubScheduleDto, {
+                title: 'a'.repeat(101),
                 type: 'etc',
                 is_public: 'true',
+                location: 'a'.repeat(101),
                 external_url: 'a'.repeat(2049),
             });
 
             expect(errors.map((error) => error.property)).toEqual(
-                expect.arrayContaining(['type', 'is_public', 'external_url']),
+                expect.arrayContaining([
+                    'title',
+                    'type',
+                    'is_public',
+                    'location',
+                    'external_url',
+                ]),
             );
         });
 


### PR DESCRIPTION
### Motivation

- Prevent accepting route-injected `club_id` in request bodies and enforce length constraints for schedule text fields to match DB limits and API expectations.
- Ensure public schedule listings exclude schedules whose parent club is soft-deleted.
- Make owner-scoped updates and soft-deletes strictly conditional on `club_id` at the query level to avoid accidental cross-club modifications.

### Description

- Removed `club_id` from `CreateClubScheduleDto` and added `@MaxLength(100)` to `title` and `location` fields in `CreateClubScheduleDto`.
- Stopped mutating DTOs in `ClubsController` by removing `dto.club_id = ...` and now pass the route `clubId` directly to service calls in `createSchedule` and `updateSchedule`.
- Rewrote `findPublicByClubId` to use `createQueryBuilder` with a `leftJoinAndSelect('schedule.club', 'club')` and added a `club.deleted_at IS NULL` filter to exclude soft-deleted clubs.
- Added `updateOwnedSchedule` and `softDeleteOwned` helpers that perform owner-scoped updates using `createQueryBuilder().update(...).set(...).where(...).andWhere(...).execute()` and switched `update`/`removeByClubId` to use these helpers.
- Changed update payload typing to `QueryDeepPartialEntity<ClubSchedule>` and adjusted related imports.
- Updated unit tests and documentation expectations to match the new behavior and DTO shape, including adapting mocks to use query builder methods and adding a test for `removeByClubId`.

### Testing

- Ran `club_schedules.service.spec.ts` unit tests which were updated to mock the query builder and passed.
- Ran `clubs.controller.spec.ts` unit tests which were updated to expect no `club_id` injection and passed.
- Ran `dto-validation.spec.ts` unit tests which were updated to reflect new DTO rules (max lengths and removed `club_id`) and passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0b137065e0832999dffeab89f18fb9)