### PR TITLE
fix: club 수정 시 president_id가 0이면 검증을 건너뛰던 falsy 체크 수정

### DIFF
--- a/src/v1/clubs/clubs.service.ts
+++ b/src/v1/clubs/clubs.service.ts
@@ -68,13 +68,10 @@ export class ClubsService {
     }
 
     async update(id: number, updateClubDto: UpdateClubDto) {
-        if (updateClubDto.president_id) {
+        if (updateClubDto.president_id !== undefined) {
             // 동아리 회장 변경 시
-            let president;
             try {
-                president = await this.usersService.findOne(
-                    updateClubDto.president_id,
-                );
+                await this.usersService.findOne(updateClubDto.president_id);
             } catch (error) {
                 if (error instanceof NotFoundException) {
                     throw new HttpException(
@@ -83,12 +80,6 @@ export class ClubsService {
                     );
                 }
                 throw error;
-            }
-            if (!president) {
-                throw new HttpException(
-                    '존재하지 않는 사용자입니다.',
-                    HttpStatus.BAD_REQUEST,
-                );
             }
         }
 


### PR DESCRIPTION
president_id 존재 여부를 truthy 체크하면 0이 falsy로 취급되어 사용자 검증이 스킵되는 문제가 있었음. undefined 체크로 변경하고, usersService.findOne이 더 이상 null을 반환하지 않아 사용되지 않던 죽은 코드도 제거.