### PR TITLE
fix(clubs): allow icon_url in club update DTO

### DIFF
--- a/src/v1/clubs/dto/create-club.dto.ts
+++ b/src/v1/clubs/dto/create-club.dto.ts
@@ -51,6 +51,10 @@ export class CreateClubDto {
     main_activities?: string;
 
     @IsOptional()
+    @IsString()
+    icon_url?: string | null;
+
+    @IsOptional()
     @IsNumber()
     president_id?: number;
 }

--- a/src/v1/clubs/entities/club.entity.ts
+++ b/src/v1/clubs/entities/club.entity.ts
@@ -43,7 +43,7 @@ export class Club {
     description: string;
 
     @Column({ type: 'varchar', length: 255, nullable: true })
-    icon_url: string;
+    icon_url: string | null;
 
     @Column({ type: 'varchar', length: 100, nullable: true })
     location: string;


### PR DESCRIPTION
PUT /v1/clubs/:id used ValidationPipe(forbidNonWhitelisted: true) but CreateClubDto/UpdateClubDto never declared icon_url, so requests that included it (e.g. clearing the icon) were rejected as an unknown field even though the DB column and update() already supported it.