### PR TITLE
feat: 관리자 대시보드 전용 집계 엔드포인트 추가

### DIFF
--- a/docs/evals/success-criteria.md
+++ b/docs/evals/success-criteria.md
@@ -136,6 +136,19 @@
 
 - [main_banners.controller.spec.ts](../../src/v1/main_banners/main_banners.controller.spec.ts)
 
+## Dashboard
+
+### 관리자 홈 집계
+
+- 동아리 집계는 삭제되지 않은 동아리의 전체 수와 모집중 수를 반환해야 하며, 최근 항목은 생성일 역순으로 최대 4개까지 `id`, `name`, `category`, `is_recruiting` 필드만 포함해야 한다.
+- 사용자 집계는 삭제되지 않고 시스템 계정이 아닌 사용자의 전체 수를 반환해야 하며, 최근 항목은 생성일 역순으로 최대 4개까지 `id`, `name`, `login_id`, `role`, `created_at` 필드만 포함하고 비밀번호 해시와 refresh_token은 절대 포함하지 않아야 한다.
+- 배너 집계는 삭제되지 않은 전체 배너 수와 `is_active`가 true인 배너 수를 반환해야 한다.
+- 일정 집계는 서울 기준 이번 달 범위(이번 달 1일 00:00 이상, 다음 달 1일 00:00 미만)와 겹치는 삭제되지 않은 일정 수를 반환해야 하며, 다음 달 1일 00:00 정각에 시작하는 일정은 이번 달 집계에서 제외해야 한다.
+
+관련 테스트:
+
+- [dashboard.service.spec.ts](../../src/v1/dashboard/dashboard.service.spec.ts)
+
 ## Auth
 
 ### 로그인과 refresh token

--- a/docs/evals/test-inventory.md
+++ b/docs/evals/test-inventory.md
@@ -28,6 +28,7 @@
 | validation     | [dto-validation.spec.ts](../../src/v1/dto-validation.spec.ts)                                      | code-graded | 요청 DTO 필수/선택/타입 런타임 validation 계약; 400 message 한글화는 common helper spec 참조 |
 | main banners   | [main_banners.service.spec.ts](../../src/v1/main_banners/main_banners.service.spec.ts)             | code-graded | 메인 배너 service 생성/수정/삭제/관리자 목록/활성 목록/검증 계약       |
 | main banners   | [main_banners.controller.spec.ts](../../src/v1/main_banners/main_banners.controller.spec.ts)       | code-graded | 메인 배너 조회 위임, 이미지 업로드 controller 계약                     |
+| dashboard      | [dashboard.service.spec.ts](../../src/v1/dashboard/dashboard.service.spec.ts)                      | code-graded | 관리자 홈 집계(동아리/사용자/배너/일정) select 필드, 정렬, 이번 달 범위 반개방 구간 계약 |
 | auth           | [auth.service.spec.ts](../../src/v1/auth/auth.service.spec.ts)                                     | code-graded | 로그인 실패/성공, refresh token 실패/rotation 계약                     |
 | auth           | [jwt.strategy.spec.ts](../../src/v1/auth/strategies/jwt.strategy.spec.ts)                          | code-graded | JWT payload 사용자 정보/club_id 검증 계약                              |
 

--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -13,6 +13,7 @@ import { getRequiredEnv } from './common/lib/utils';
 import { MainBannersModule } from './v1/main_banners/main_banners.module';
 import { ClubSchedulesModule } from './v1/club_schedules/club_schedules.module';
 import { PublicClubSchedulesModule } from './v1/club_schedules/public_club_schedules.module';
+import { DashboardModule } from './v1/dashboard/dashboard.module';
 
 @Module({
     imports: [
@@ -47,6 +48,7 @@ import { PublicClubSchedulesModule } from './v1/club_schedules/public_club_sched
                     { path: 'main-banners', module: MainBannersModule },
                     { path: 'auth', module: AuthModule },
                     { path: 'healthCheck', module: HealthModule },
+                    { path: 'dashboard', module: DashboardModule },
                 ],
             },
         ]),
@@ -59,6 +61,7 @@ import { PublicClubSchedulesModule } from './v1/club_schedules/public_club_sched
         PublicClubSchedulesModule,
         MainBannersModule,
         AuthModule,
+        DashboardModule,
     ],
     controllers: [AppController],
     providers: [AppService],

--- a/src/v1/dashboard/dashboard.controller.ts
+++ b/src/v1/dashboard/dashboard.controller.ts
@@ -1,0 +1,18 @@
+import { Controller, Get, UseGuards } from '@nestjs/common';
+import { ROLES } from '../auth/constants/roles';
+import { Roles } from '../auth/decorators/roles.decorator';
+import { JwtAuthGuard } from '../auth/guards/jwt-auth.guard';
+import { RoleGuard } from '../auth/guards/role.guard';
+import { DashboardService } from './dashboard.service';
+
+@Controller()
+@UseGuards(JwtAuthGuard, RoleGuard)
+@Roles(ROLES.ADMIN)
+export class DashboardController {
+    constructor(private readonly dashboardService: DashboardService) {}
+
+    @Get()
+    async getDashboard() {
+        return await this.dashboardService.getDashboard();
+    }
+}

--- a/src/v1/dashboard/dashboard.module.ts
+++ b/src/v1/dashboard/dashboard.module.ts
@@ -1,0 +1,17 @@
+import { Module } from '@nestjs/common';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { Club } from '../clubs/entities/club.entity';
+import { ClubSchedule } from '../club_schedules/entities/club_schedule.entity';
+import { MainBanner } from '../main_banners/entities/main_banner.entity';
+import { User } from '../users/entities/user.entity';
+import { DashboardController } from './dashboard.controller';
+import { DashboardService } from './dashboard.service';
+
+@Module({
+    imports: [
+        TypeOrmModule.forFeature([Club, User, MainBanner, ClubSchedule]),
+    ],
+    controllers: [DashboardController],
+    providers: [DashboardService],
+})
+export class DashboardModule {}

--- a/src/v1/dashboard/dashboard.service.spec.ts
+++ b/src/v1/dashboard/dashboard.service.spec.ts
@@ -1,0 +1,192 @@
+import { Repository } from 'typeorm';
+import { Club } from '../clubs/entities/club.entity';
+import { ClubSchedule } from '../club_schedules/entities/club_schedule.entity';
+import { MainBanner } from '../main_banners/entities/main_banner.entity';
+import { User } from '../users/entities/user.entity';
+import { DashboardService } from './dashboard.service';
+
+const seoulDate = (value: string) => new Date(`${value}+09:00`);
+
+describe('DashboardService', () => {
+    let service: DashboardService;
+    let clubRepository: { count: jest.Mock; find: jest.Mock };
+    let userRepository: { count: jest.Mock; find: jest.Mock };
+    let mainBannerRepository: { count: jest.Mock };
+    let scheduleQueryBuilder: {
+        where: jest.Mock;
+        andWhere: jest.Mock;
+        getCount: jest.Mock;
+    };
+    let clubScheduleRepository: { createQueryBuilder: jest.Mock };
+
+    beforeEach(() => {
+        clubRepository = {
+            count: jest.fn().mockResolvedValue(0),
+            find: jest.fn().mockResolvedValue([]),
+        };
+        userRepository = {
+            count: jest.fn().mockResolvedValue(0),
+            find: jest.fn().mockResolvedValue([]),
+        };
+        mainBannerRepository = {
+            count: jest.fn().mockResolvedValue(0),
+        };
+        scheduleQueryBuilder = {
+            where: jest.fn(),
+            andWhere: jest.fn(),
+            getCount: jest.fn().mockResolvedValue(0),
+        };
+        scheduleQueryBuilder.where.mockReturnValue(scheduleQueryBuilder);
+        scheduleQueryBuilder.andWhere.mockReturnValue(scheduleQueryBuilder);
+        clubScheduleRepository = {
+            createQueryBuilder: jest.fn().mockReturnValue(scheduleQueryBuilder),
+        };
+
+        service = new DashboardService(
+            clubRepository as unknown as Repository<Club>,
+            userRepository as unknown as Repository<User>,
+            mainBannerRepository as unknown as Repository<MainBanner>,
+            clubScheduleRepository as unknown as Repository<ClubSchedule>,
+        );
+    });
+
+    afterEach(() => {
+        jest.useRealTimers();
+    });
+
+    describe('동아리 요약', () => {
+        it('삭제되지 않은 전체/모집중 개수와 최근 4개를 생성일 역순으로 조회한다', async () => {
+            clubRepository.count
+                .mockResolvedValueOnce(12)
+                .mockResolvedValueOnce(3);
+            const recentClubs = [{ id: 1 }];
+            clubRepository.find.mockResolvedValue(recentClubs);
+
+            const result = await service.getDashboard();
+
+            expect(clubRepository.count).toHaveBeenNthCalledWith(1, {
+                where: { deleted_at: expect.anything() },
+            });
+            expect(clubRepository.count).toHaveBeenNthCalledWith(2, {
+                where: { deleted_at: expect.anything(), is_recruiting: true },
+            });
+            expect(clubRepository.find).toHaveBeenCalledWith({
+                where: { deleted_at: expect.anything() },
+                select: ['id', 'name', 'category', 'is_recruiting'],
+                order: { created_at: 'DESC' },
+                take: 4,
+            });
+            expect(result.clubs).toEqual({
+                total: 12,
+                recruiting: 3,
+                recent: recentClubs,
+            });
+        });
+    });
+
+    describe('사용자 요약', () => {
+        it('삭제되지 않고 시스템 계정이 아닌 사용자만 집계하며 비밀번호/refresh_token은 select하지 않는다', async () => {
+            userRepository.count.mockResolvedValue(7);
+            const recentUsers = [{ id: 1 }];
+            userRepository.find.mockResolvedValue(recentUsers);
+
+            const result = await service.getDashboard();
+
+            const countArgs = userRepository.count.mock.calls[0][0];
+            expect(countArgs.where).toEqual(
+                expect.objectContaining({
+                    deleted_at: expect.anything(),
+                    is_system: false,
+                }),
+            );
+
+            const findArgs = userRepository.find.mock.calls[0][0];
+            expect(findArgs.where).toEqual(
+                expect.objectContaining({
+                    deleted_at: expect.anything(),
+                    is_system: false,
+                }),
+            );
+            expect(findArgs.select).toEqual([
+                'id',
+                'name',
+                'login_id',
+                'role',
+                'created_at',
+            ]);
+            expect(findArgs.select).not.toContain('password');
+            expect(findArgs.select).not.toContain('refresh_token');
+            expect(findArgs.order).toEqual({ created_at: 'DESC' });
+            expect(findArgs.take).toBe(4);
+
+            expect(result.users).toEqual({ total: 7, recent: recentUsers });
+        });
+    });
+
+    describe('배너 요약', () => {
+        it('삭제되지 않은 전체 배너 수와 활성 배너 수를 집계한다', async () => {
+            mainBannerRepository.count
+                .mockResolvedValueOnce(5)
+                .mockResolvedValueOnce(2);
+
+            const result = await service.getDashboard();
+
+            expect(mainBannerRepository.count).toHaveBeenNthCalledWith(1, {
+                where: { deleted_at: expect.anything() },
+            });
+            expect(mainBannerRepository.count).toHaveBeenNthCalledWith(2, {
+                where: { deleted_at: expect.anything(), is_active: true },
+            });
+            expect(result.banners).toEqual({ total: 5, active: 2 });
+        });
+    });
+
+    describe('일정 요약', () => {
+        it('이번 달 범위는 서울 기준 월초(from 이상)~다음 달 월초(to 미만) 반개방 구간으로 조회한다', async () => {
+            jest.useFakeTimers().setSystemTime(new Date('2026-08-15T03:00:00.000Z'));
+            scheduleQueryBuilder.getCount.mockResolvedValue(9);
+
+            const result = await service.getDashboard();
+
+            expect(scheduleQueryBuilder.andWhere).toHaveBeenNthCalledWith(
+                1,
+                'schedule.start_at < :to',
+                { to: seoulDate('2026-09-01T00:00:00') },
+            );
+            expect(scheduleQueryBuilder.andWhere).toHaveBeenNthCalledWith(
+                2,
+                'schedule.end_at >= :from',
+                { from: seoulDate('2026-08-01T00:00:00') },
+            );
+            expect(result.schedules).toEqual({ thisMonth: 9 });
+        });
+
+        it('12월에는 다음 해 1월 1일을 상한으로 사용한다', async () => {
+            jest.useFakeTimers().setSystemTime(new Date('2026-12-15T03:00:00.000Z'));
+            scheduleQueryBuilder.getCount.mockResolvedValue(1);
+
+            await service.getDashboard();
+
+            expect(scheduleQueryBuilder.andWhere).toHaveBeenNthCalledWith(
+                1,
+                'schedule.start_at < :to',
+                { to: seoulDate('2027-01-01T00:00:00') },
+            );
+            expect(scheduleQueryBuilder.andWhere).toHaveBeenNthCalledWith(
+                2,
+                'schedule.end_at >= :from',
+                { from: seoulDate('2026-12-01T00:00:00') },
+            );
+        });
+
+        it('다음 달 월초 정각에 시작하는 일정은 이번 달 집계에서 제외된다(상한 미포함 검증)', async () => {
+            jest.useFakeTimers().setSystemTime(new Date('2026-08-15T03:00:00.000Z'));
+
+            await service.getDashboard();
+
+            const [expression] = scheduleQueryBuilder.andWhere.mock.calls[0];
+            expect(expression).not.toContain('<=');
+            expect(expression).toBe('schedule.start_at < :to');
+        });
+    });
+});

--- a/src/v1/dashboard/dashboard.service.ts
+++ b/src/v1/dashboard/dashboard.service.ts
@@ -83,7 +83,7 @@ export class DashboardService {
         const thisMonth = await this.clubScheduleRepository
             .createQueryBuilder('schedule')
             .where('schedule.deleted_at IS NULL')
-            .andWhere('schedule.start_at <= :to', { to })
+            .andWhere('schedule.start_at < :to', { to })
             .andWhere('schedule.end_at >= :from', { from })
             .getCount();
 

--- a/src/v1/dashboard/dashboard.service.ts
+++ b/src/v1/dashboard/dashboard.service.ts
@@ -1,0 +1,109 @@
+import { Injectable } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { IsNull, Repository } from 'typeorm';
+import { parseSeoulDateTime } from '../../common/lib/date-time';
+import { Club } from '../clubs/entities/club.entity';
+import { ClubSchedule } from '../club_schedules/entities/club_schedule.entity';
+import { MainBanner } from '../main_banners/entities/main_banner.entity';
+import { User } from '../users/entities/user.entity';
+
+const RECENT_ITEMS_LIMIT = 4;
+
+@Injectable()
+export class DashboardService {
+    constructor(
+        @InjectRepository(Club)
+        private readonly clubRepository: Repository<Club>,
+        @InjectRepository(User)
+        private readonly userRepository: Repository<User>,
+        @InjectRepository(MainBanner)
+        private readonly mainBannerRepository: Repository<MainBanner>,
+        @InjectRepository(ClubSchedule)
+        private readonly clubScheduleRepository: Repository<ClubSchedule>,
+    ) {}
+
+    async getDashboard() {
+        const [clubs, users, banners, schedules] = await Promise.all([
+            this.getClubSummary(),
+            this.getUserSummary(),
+            this.getBannerSummary(),
+            this.getScheduleSummary(),
+        ]);
+
+        return { clubs, users, banners, schedules };
+    }
+
+    private async getClubSummary() {
+        const [total, recruiting, recent] = await Promise.all([
+            this.clubRepository.count({ where: { deleted_at: IsNull() } }),
+            this.clubRepository.count({
+                where: { deleted_at: IsNull(), is_recruiting: true },
+            }),
+            this.clubRepository.find({
+                where: { deleted_at: IsNull() },
+                select: ['id', 'name', 'category', 'is_recruiting'],
+                order: { created_at: 'DESC' },
+                take: RECENT_ITEMS_LIMIT,
+            }),
+        ]);
+
+        return { total, recruiting, recent };
+    }
+
+    private async getUserSummary() {
+        const [total, recent] = await Promise.all([
+            this.userRepository.count({
+                where: { deleted_at: IsNull(), is_system: false },
+            }),
+            this.userRepository.find({
+                where: { deleted_at: IsNull(), is_system: false },
+                select: ['id', 'name', 'login_id', 'role', 'created_at'],
+                order: { created_at: 'DESC' },
+                take: RECENT_ITEMS_LIMIT,
+            }),
+        ]);
+
+        return { total, recent };
+    }
+
+    private async getBannerSummary() {
+        const [total, active] = await Promise.all([
+            this.mainBannerRepository.count({ where: { deleted_at: IsNull() } }),
+            this.mainBannerRepository.count({
+                where: { deleted_at: IsNull(), is_active: true },
+            }),
+        ]);
+
+        return { total, active };
+    }
+
+    private async getScheduleSummary() {
+        const { from, to } = this.getCurrentMonthRangeInSeoul();
+
+        const thisMonth = await this.clubScheduleRepository
+            .createQueryBuilder('schedule')
+            .where('schedule.deleted_at IS NULL')
+            .andWhere('schedule.start_at <= :to', { to })
+            .andWhere('schedule.end_at >= :from', { from })
+            .getCount();
+
+        return { thisMonth };
+    }
+
+    private getCurrentMonthRangeInSeoul(): { from: Date; to: Date } {
+        const seoulNow = new Date(
+            new Date().toLocaleString('en-US', { timeZone: 'Asia/Seoul' }),
+        );
+        const year = seoulNow.getFullYear();
+        const month = seoulNow.getMonth();
+        const pad = (value: number) => String(value).padStart(2, '0');
+
+        const from = parseSeoulDateTime(`${year}-${pad(month + 1)}-01`);
+
+        const nextMonth = month === 11 ? 0 : month + 1;
+        const nextYear = month === 11 ? year + 1 : year;
+        const to = parseSeoulDateTime(`${nextYear}-${pad(nextMonth + 1)}-01`);
+
+        return { from, to };
+    }
+}


### PR DESCRIPTION
## Summary
- 관리자 홈 화면이 `/clubs`, `/users`, `/main-banners/admin`, `/club-schedules/calendar` 4개 API를 그대로 호출해 사용자 응답에 비밀번호 해시·refresh_token까지 노출되던 문제를 해결
- `GET /v1/dashboard`를 신설해 동아리/사용자/배너/일정 요약을 서버에서 집계 (필요한 필드만 select, 최신순 정렬)
- "최근 동아리/사용자" 목록이 정렬 없이 배열 앞부분만 잘라 쓰던 것을 `created_at DESC` 기준으로 명확히 정렬

## Test plan
- [x] `npx tsc --noEmit` 통과
- [x] `npx jest src/v1/users` 통과 (기존 테스트 영향 없음 확인)
- [ ] 스테이징에서 관리자 계정으로 `GET /v1/dashboard` 응답 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)