### PR TITLE
fix: 피드백 GitHub 이슈 생성 실패 시 원인을 로깅

### DIFF
--- a/src/v1/feedback/feedback.service.spec.ts
+++ b/src/v1/feedback/feedback.service.spec.ts
@@ -1,4 +1,4 @@
-import { InternalServerErrorException } from '@nestjs/common';
+import { InternalServerErrorException, Logger } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
 import { FeedbackService, buildFeedbackIssue } from './feedback.service';
 
@@ -114,12 +114,13 @@ describe('FeedbackService', () => {
         );
     });
 
-    it('GitHub API가 실패 응답을 반환하면 InternalServerErrorException을 던진다', async () => {
+    it('GitHub API가 실패 응답을 반환하면 InternalServerErrorException을 던지고 원인을 로깅한다', async () => {
         fetchMock.mockResolvedValue({
             ok: false,
             status: 401,
             json: jest.fn().mockResolvedValue({}),
         });
+        const loggerErrorSpy = jest.spyOn(Logger.prototype, 'error').mockImplementation();
 
         await expect(
             service.create(
@@ -127,10 +128,17 @@ describe('FeedbackService', () => {
                 { role: 'admin', club_id: null },
             ),
         ).rejects.toThrow(InternalServerErrorException);
+        expect(loggerErrorSpy).toHaveBeenCalledWith(
+            'GitHub 이슈 생성 실패',
+            expect.stringContaining('GitHub API 응답 실패 (status: 401)'),
+        );
+
+        loggerErrorSpy.mockRestore();
     });
 
-    it('fetch가 네트워크 오류로 실패하면 InternalServerErrorException을 던진다', async () => {
+    it('fetch가 네트워크 오류로 실패하면 InternalServerErrorException을 던지고 원인을 로깅한다', async () => {
         fetchMock.mockRejectedValue(new Error('network down'));
+        const loggerErrorSpy = jest.spyOn(Logger.prototype, 'error').mockImplementation();
 
         await expect(
             service.create(
@@ -138,5 +146,8 @@ describe('FeedbackService', () => {
                 { role: 'president', club_id: 5 },
             ),
         ).rejects.toThrow(InternalServerErrorException);
+        expect(loggerErrorSpy).toHaveBeenCalledWith('GitHub 이슈 생성 실패', expect.stringContaining('network down'));
+
+        loggerErrorSpy.mockRestore();
     });
 });

--- a/src/v1/feedback/feedback.service.ts
+++ b/src/v1/feedback/feedback.service.ts
@@ -1,4 +1,4 @@
-import { Injectable, InternalServerErrorException } from '@nestjs/common';
+import { Injectable, InternalServerErrorException, Logger } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
 import { getRequiredEnv } from '../../common/lib/utils';
 import { CreateFeedbackDto, FeedbackCategory } from './dto/create-feedback.dto';
@@ -53,6 +53,8 @@ ${content.trim()}`;
 
 @Injectable()
 export class FeedbackService {
+    private readonly logger = new Logger(FeedbackService.name);
+
     constructor(private readonly config: ConfigService) {}
 
     async create(dto: CreateFeedbackDto, requester: FeedbackRequester): Promise<{ issueUrl: string; issueNumber: number }> {
@@ -86,6 +88,7 @@ export class FeedbackService {
             const issue = (await response.json()) as { html_url: string; number: number };
             return { issueUrl: issue.html_url, issueNumber: issue.number };
         } catch (err) {
+            this.logger.error('GitHub 이슈 생성 실패', err instanceof Error ? err.stack : err);
             throw new InternalServerErrorException('피드백 이슈 생성에 실패했습니다.', {
                 cause: err instanceof Error ? err : undefined,
             });


### PR DESCRIPTION
## 배경
관리자 피드백을 GitHub Issue로 등록하는 기능(`FeedbackService.create`)에서 GitHub API 호출이 실패하면(토큰/레포 설정 누락, 401/403/404, 네트워크 오류 등) `InternalServerErrorException`에 원본 에러를 `cause`로만 붙여 던지고 있었습니다.

- NestJS 기본 `BaseExceptionFilter`는 `HttpException` 인스턴스는 로깅하지 않고 응답만 내려보냅니다.
- 응답 직렬화(`extractHttpExceptionMessage`/`formatHttpExceptionDetail`)도 `getResponse()`만 읽고 `cause`는 보지 않습니다.

결과적으로 GitHub 이슈 생성이 실패해도 서버 로그 어디에도 원인이 남지 않아, 실패 사실은 클라이언트 토스트로 알 수 있어도 "왜" 실패했는지는 서버 프로세스 로그를 확인해도 알 수 없었습니다.

## 변경 사항
- `FeedbackService`에 `Logger`를 추가하고, catch 블록에서 클라이언트에 일반화된 메시지를 던지기 전에 `this.logger.error('GitHub 이슈 생성 실패', err.stack)`으로 원인을 먼저 남기도록 수정
- 기존 실패 케이스 테스트(GitHub 401 응답, 네트워크 오류)에 `Logger.error` 호출 검증 추가

## 검증
- `yarn verify:fast` (문서 계약 검증 + 타입체크 + 전체 테스트 190개) 통과

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>